### PR TITLE
Basic handling of file and object hashes

### DIFF
--- a/src/outpack/hash.py
+++ b/src/outpack/hash.py
@@ -5,10 +5,10 @@ from dataclasses import dataclass
 @dataclass
 class Hash:
     algorithm: str
-    digest: str
+    value: str
 
     def __str__(self):
-        return f"{self.algorithm}:{self.digest}"
+        return f"{self.algorithm}:{self.value}"
 
 
 def hash_file(path, algorithm="sha256"):

--- a/src/outpack/hash.py
+++ b/src/outpack/hash.py
@@ -1,0 +1,47 @@
+import hashlib
+from dataclasses import dataclass
+
+
+@dataclass
+class Hash:
+    algorithm: str
+    digest: str
+
+    def __str__(self):
+        return f"{self.algorithm}:{self.digest}"
+
+
+def hash_file(path, algorithm="sha256"):
+    h = hashlib.new(algorithm)
+    blocksize = 128 * h.block_size
+    with open(path, "rb") as f:
+        while chunk := f.read(blocksize):
+            h.update(chunk)
+    return Hash(algorithm, h.hexdigest())
+
+
+def hash_string(data, algorithm):
+    h = hashlib.new(algorithm)
+    h.update(data.encode())
+    h.hexdigest()
+    return Hash(algorithm, h.hexdigest())
+
+
+def hash_parse(string):
+    if type(string) == Hash:
+        return string
+    return Hash(*string.split(":"))
+
+
+def hash_validate(path, expected):
+    h = hash_parse(expected)
+    found = hash_file(path, h.algorithm)
+    if found != h:
+        msg = "\n".join(
+            [
+                f"Hash of '{path}' does not match:",
+                f" - expected: {expected}",
+                f" - found: {found}",
+            ]
+        )
+        raise Exception(msg)

--- a/tests/test_hash.py
+++ b/tests/test_hash.py
@@ -20,14 +20,14 @@ def test_hash_file(tmp_path):
     with open(p, "wb") as f:
         f.write(bytes(range(256)))
     h = hash_file(p, "md5")
-    assert h == Hash(algorithm="md5", digest="e2c865db4162bed963bfaa9ef6ac18f0")
+    assert h == Hash(algorithm="md5", value="e2c865db4162bed963bfaa9ef6ac18f0")
 
 
 def test_hash_validate_is_silent_on_success(tmp_path):
     p = tmp_path / "file"
     with open(p, "wb") as f:
         f.write(bytes(range(256)))
-    h = Hash(algorithm="md5", digest="e2c865db4162bed963bfaa9ef6ac18f0")
+    h = Hash(algorithm="md5", value="e2c865db4162bed963bfaa9ef6ac18f0")
     # Just a test that there is no error:
     hash_validate(p, h)
 

--- a/tests/test_hash.py
+++ b/tests/test_hash.py
@@ -1,0 +1,37 @@
+import pytest
+
+from outpack.hash import Hash, hash_file, hash_parse, hash_string, hash_validate
+
+
+def test_hash_string():
+    assert hash_string("hello outpack", "md5") == Hash(
+        "md5", "7c4d97e580abb6c2ffb8b1872907d84b"
+    )
+
+
+def test_parse_hash():
+    h = "md5:7c4d97e580abb6c2ffb8b1872907d84b"
+    assert hash_parse(h) == Hash("md5", "7c4d97e580abb6c2ffb8b1872907d84b")
+    assert str(hash_parse(h)) == h
+
+
+def test_hash_file(tmp_path):
+    p = tmp_path / "file"
+    with open(p, "wb") as f:
+        f.write(bytes(range(256)))
+    h = hash_file(p, "md5")
+    assert h == Hash(algorithm="md5", digest="e2c865db4162bed963bfaa9ef6ac18f0")
+
+
+def test_hash_validate_is_silent_on_success(tmp_path):
+    p = tmp_path / "file"
+    with open(p, "wb") as f:
+        f.write(bytes(range(256)))
+    h = Hash(algorithm="md5", digest="e2c865db4162bed963bfaa9ef6ac18f0")
+    # Just a test that there is no error:
+    hash_validate(p, h)
+
+    h.algorithm = "sha1"
+    with pytest.raises(Exception) as e:
+        hash_validate(p, h)
+    assert e.match("Hash of '.+' does not match:")


### PR DESCRIPTION
This PR copies in code from the unmerged original python PR (https://github.com/mrc-ide/outpack-py/pull/2) - just the first half, implementing support for working with file and object hashes.

~I've called these "digests" here (basically replace all "hash" with "digest") to avoid style warnings about clashing with the python builtin. We could disable this warning alternatively, but I don't hate this name, and it's not like we are depending on word-for-word equivalence everywhere. That said, hash does appear in the outpack metadata schema so open to suggestion and discussion here. See bf069c6 for an implementation that uses `hash` everywhere.~