### PR TITLE
Basic implementation of filestore

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -132,6 +132,8 @@ ignore = [
   "S105", "S106", "S107",
   # Ignore complexity
   "C901", "PLR0911", "PLR0912", "PLR0913", "PLR0915",
+  # Ignore shadowing
+  "A002"
 ]
 unfixable = [
   # Don't touch unused imports

--- a/src/outpack/config.py
+++ b/src/outpack/config.py
@@ -28,10 +28,10 @@ class ConfigCore:
     require_complete_tree: bool
 
 
-# Note, using A002 and A003 noqa here to allow 'type' to be used as a
-# field name and argument; this keeps the class close to the json
-# names, and means that things read nicely (location.type rather than
-# location.location_type)
+# Note, using A002 (globally) and A003 noqa here to allow 'type' to be
+# used as a field name and argument; this keeps the class close to the
+# json names, and means that things read nicely (location.type rather
+# than location.location_type). A similar issue occurs with 'hash'
 @dataclass_json
 @dataclass
 class Location:
@@ -39,7 +39,7 @@ class Location:
     type: str  # noqa: A003
     args: Optional[dict] = None
 
-    def __init__(self, name, type, args=None):  # noqa: A002
+    def __init__(self, name, type, args=None):
         self.name = name
         self.type = type
         self.args = args

--- a/src/outpack/filestore.py
+++ b/src/outpack/filestore.py
@@ -1,0 +1,50 @@
+import os
+import os.path
+import shutil
+import stat
+
+from outpack.hash import Hash, hash_parse, hash_validate
+
+
+class FileStore:
+    def __init__(self, path):
+        self._path = path
+        os.makedirs(path, exist_ok=True)
+
+    def filename(self, hash):
+        dat = hash_parse(hash)
+        return os.path.join(
+            self._path, dat.algorithm, dat.value[:2], dat.value[2:]
+        )
+
+    def get(self, hash, dst):
+        src = self.filename(hash)
+        if not os.path.exists(src):
+            msg = f"Hash '{hash}' not found in store"
+            raise Exception(msg)
+        os.makedirs(os.path.dirname(dst), exist_ok=True)
+        shutil.copyfile(src, dst)
+
+    def exists(self, hash):
+        return os.path.exists(self.filename(hash))
+
+    def put(self, src, hash):
+        hash_validate(src, hash)
+        dst = self.filename(hash)
+        if not os.path.exists(dst):
+            os.makedirs(os.path.dirname(dst), exist_ok=True)
+            shutil.copyfile(src, dst)
+            os.chmod(dst, stat.S_IREAD | stat.S_IRGRP | stat.S_IROTH)
+        return hash
+
+    def ls(self):
+        # Lots of ways of pulling this off with higer order functions
+        # (os.walk, Path.glob etc), but this is probably clearest.
+        ret = []
+        for algorithm in os.listdir(self._path):
+            path_alg = os.path.join(self._path, algorithm)
+            for prefix in os.listdir(path_alg):
+                path_prefix = os.path.join(path_alg, prefix)
+                for suffix in os.listdir(path_prefix):
+                    ret.append(Hash(algorithm, prefix + suffix))
+        return ret

--- a/tests/test_filestore.py
+++ b/tests/test_filestore.py
@@ -1,0 +1,54 @@
+import random
+
+import pytest
+
+from outpack.filestore import FileStore
+from outpack.hash import Hash, hash_file
+
+
+def randstr(n):
+    return "".join([str(random.randint(0, 9)) for _ in range(n)])  #  noqa: S311
+
+
+def test_can_create_store(tmp_path):
+    p = str(tmp_path / "store")
+    s = FileStore(p)
+    assert s.ls() == []
+
+
+def test_can_store_files(tmp_path):
+    tmp = tmp_path / "tmp"
+    tmp.mkdir()
+    letters = [chr(i + ord("a")) for i in range(10)]
+    for i in range(10):
+        with open(tmp_path / "tmp" / letters[i], "w") as f:
+            f.write(randstr(10))
+
+    s = FileStore(str(tmp_path / "store"))
+    p = tmp_path / "tmp" / "a"
+    h = hash_file(p, "md5")
+    assert not s.exists(h)
+    assert s.put(p, h) == h
+    assert s.exists(h)
+    assert s.ls() == [h]
+
+    dest = tmp_path / "dest"
+    s.get(h, dest)
+    assert dest.exists()
+    assert hash_file(dest, "md5") == h
+
+    for i in range(10):
+        p = tmp_path / "tmp" / letters[i]
+        s.put(p, hash_file(p, "md5"))
+
+    assert len(s.ls()) == 10
+
+
+def test_if_hash_not_found(tmp_path):
+    p = str(tmp_path / "store")
+    s = FileStore(p)
+    h = Hash("md5", "7c4d97e580abb6c2ffb8b1872907d84b")
+    dest = tmp_path / "dest"
+    with pytest.raises(Exception) as e:
+        s.get(h, dest)
+    assert e.match("Hash 'md5:7c4d97e.+' not found in store")


### PR DESCRIPTION
Implements enough of the file store to support basic CRUD operations. Some extra stuff around temporary files, moving and complete destruction not implemented because (a) they were not there in the code I copied in from mrc-ide/outpack-py and (b) there are probably Pythonic ways of doing these things.