### PR TITLE
Add search options support

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -101,6 +101,7 @@ select = [
   "ARG",
   "B",
   "C",
+  "D",
   "DTZ",
   "E",
   "EM",
@@ -132,6 +133,8 @@ ignore = [
   "S105", "S106", "S107",
   # Ignore complexity
   "C901", "PLR0911", "PLR0912", "PLR0913", "PLR0915",
+  # Don't require docstrings everywhere for now
+  "D100", "D101", "D103", "D104", "D105"
 ]
 unfixable = [
   # Don't touch unused imports
@@ -147,6 +150,9 @@ ban-relative-imports = "all"
 [tool.ruff.per-file-ignores]
 # Tests can use magic values, assertions, and relative imports
 "tests/**/*" = ["PLR2004", "S101", "TID252"]
+
+[tool.ruff.pydocstyle]
+convention = "numpy"
 
 [tool.coverage.run]
 source_pkgs = ["outpack", "tests"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -134,7 +134,7 @@ ignore = [
   # Ignore complexity
   "C901", "PLR0911", "PLR0912", "PLR0913", "PLR0915",
   # Don't require docstrings everywhere for now
-  "D100", "D101", "D103", "D104", "D105",
+  "D100", "D101", "D102", "D103", "D104", "D105",
   # Ignore shadowing
   "A002"
 ]

--- a/src/outpack/search_options.py
+++ b/src/outpack/search_options.py
@@ -1,0 +1,50 @@
+from dataclasses import dataclass
+from typing import List, Optional
+
+
+@dataclass
+class SearchOptions:
+    """
+    Control over how outpack will search for packets.
+
+    Attributes
+    ----------
+    location : array of strings, optional
+        Locations that will be included for search. If `None`, then all
+        known locations will be included
+    allow_remote : bool
+        Indicates if we will consider packets that are only available
+        remotely to be found.
+    pull_metadata : bool
+        Indicates if we will pull metadata from the locations before
+        searching
+    """
+
+    location: Optional[List[str]] = None
+    allow_remote: bool = False
+    pull_metadata: bool = False
+
+    @staticmethod
+    def create(obj):
+        """
+        Construct a `SearchOptions` object from some object.
+
+        Parameters
+        ----------
+        obj : any
+            Typically this will be `None` (default construct the
+            `SearchOptions` object) or a `dict` with some of the
+            fields present in `SearchOptions`. An `TypeError` is thrown
+            if any other type is passed.
+
+        Returns
+        -------
+        A new `SearchOptions` object.
+        """
+        if obj is None:
+            return SearchOptions()
+        elif isinstance(obj, dict):
+            return SearchOptions(**obj)
+        else:
+            msg = "Invalid object type for creating a SearchOptions"
+            raise TypeError(msg)

--- a/src/outpack/search_options.py
+++ b/src/outpack/search_options.py
@@ -33,9 +33,9 @@ class SearchOptions:
         ----------
         obj : any
             Typically this will be `None` (default construct the
-            `SearchOptions` object) or a `dict` with some of the
-            fields present in `SearchOptions`. An `TypeError` is thrown
-            if any other type is passed.
+            `SearchOptions` object), a `SearchOptions` object or a `dict`
+            with some of the fields present in `SearchOptions`. An
+            `TypeError` is thrown if any other type is passed.
 
         Returns
         -------
@@ -43,6 +43,8 @@ class SearchOptions:
         """
         if obj is None:
             return SearchOptions()
+        elif isinstance(obj, SearchOptions):
+            return obj
         elif isinstance(obj, dict):
             return SearchOptions(**obj)
         else:

--- a/tests/test_search_options.py
+++ b/tests/test_search_options.py
@@ -1,0 +1,37 @@
+import pytest
+
+from outpack.search_options import SearchOptions
+
+
+def test_defaults_are_reasonable():
+    opts = SearchOptions()
+    assert opts.location is None
+    assert not opts.allow_remote
+    assert not opts.pull_metadata
+
+
+def test_can_set_options():
+    opts = SearchOptions(
+        location=["a", "b"], allow_remote=True, pull_metadata=True
+    )
+    assert opts.location == ["a", "b"]
+    assert opts.allow_remote
+    assert opts.pull_metadata
+
+
+def test_can_convert_from_none():
+    assert SearchOptions.create(None) == SearchOptions()
+
+
+def test_can_convert_from_dict():
+    assert SearchOptions.create({"allow_remote": True}) == SearchOptions(
+        allow_remote=True
+    )
+    assert SearchOptions.create(
+        {"location": ["a"], "pull_metadata": True}
+    ) == SearchOptions(["a"], False, True)
+
+
+def test_can_reject_invalid_input():
+    with pytest.raises(TypeError, match="Invalid object type"):
+        SearchOptions.create([])

--- a/tests/test_search_options.py
+++ b/tests/test_search_options.py
@@ -23,6 +23,11 @@ def test_can_convert_from_none():
     assert SearchOptions.create(None) == SearchOptions()
 
 
+def test_can_convert_from_self():
+    obj = SearchOptions(["a", "b"], True)
+    assert SearchOptions.create(obj) == obj
+
+
 def test_can_convert_from_dict():
     assert SearchOptions.create({"allow_remote": True}) == SearchOptions(
         allow_remote=True


### PR DESCRIPTION
This PR implements a simple `SearchOptions` class with the same defaults and semantics as the code in R https://github.com/mrc-ide/orderly2/blob/main/R/query_search.R, though much simpler to implement with python's dataclasses

I've used the static method `create` like Rust's `::from()` but can't use `from` as it's a keyword. I am not sure if this is pythonic but it will let us be pretty relaxed about what we accept, and we should be able to follow the R implementation pretty closely