### PR TITLE
Add support for outpack ids

### DIFF
--- a/src/outpack/ids.py
+++ b/src/outpack/ids.py
@@ -1,0 +1,23 @@
+import re
+import secrets
+import time
+
+from outpack.util import iso_time_str
+
+RE_ID = re.compile("^[0-9]{8}-[0-9]{6}-[0-9a-f]{8}$")
+
+
+def fractional_to_bytes(x):
+    return f"{round((x % 1) * pow(256, 2)):04x}"
+
+
+def outpack_id():
+    t = time.time()
+    rand = secrets.token_hex(2)
+    return f"{iso_time_str(t)}-{fractional_to_bytes(t)}{rand}"
+
+
+def validate_outpack_id(x: str):
+    if not RE_ID.match(x):
+        msg = f"Malformed id '{x}'"
+        raise Exception(msg)

--- a/src/outpack/util.py
+++ b/src/outpack/util.py
@@ -1,3 +1,4 @@
+import time
 from pathlib import Path
 
 
@@ -12,3 +13,7 @@ def find_file_descend(filename, path):
         path = path.parent
 
     return None
+
+
+def iso_time_str(t):
+    return time.strftime("%Y%m%d-%H%M%S", time.gmtime(t))

--- a/tests/test_ids.py
+++ b/tests/test_ids.py
@@ -1,0 +1,22 @@
+import pytest
+
+from outpack.ids import fractional_to_bytes, outpack_id, validate_outpack_id
+
+
+def test_fractional_to_bytes():
+    assert fractional_to_bytes(1691686967.895351) == "e536"
+    assert fractional_to_bytes(100) == "0000"
+    assert fractional_to_bytes(100.0001) == "0007"
+    assert fractional_to_bytes(100.001) == "0042"
+    assert fractional_to_bytes(100.05) == "0ccd"
+
+
+def test_outpack_id_creation():
+    x = outpack_id()
+    assert len(x) == 24
+
+
+def test_outpack_id_can_be_validated():
+    validate_outpack_id("20230810-172859-6b0408e0")
+    with pytest.raises(Exception, match="Malformed id"):
+        validate_outpack_id("20230810-172859-6b0408e")

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1,4 +1,4 @@
-from outpack.util import find_file_descend
+from outpack.util import find_file_descend, iso_time_str
 
 
 def test_find_descend(tmp_path):
@@ -8,3 +8,8 @@ def test_find_descend(tmp_path):
         tmp_path / "a/b"
     )
     assert find_file_descend(".foo", tmp_path / "a") is None
+
+
+def test_convert_iso_time():
+    t = 1691686967.895351
+    assert iso_time_str(t) == "20230810-170247"


### PR DESCRIPTION
This PR adds support for creating outpack ids that match the R implementation exactly:

* Convert from seconds post 1970 to UTC
* Encode ms into hex
* Cryptographically secure random bytes for the suffix