### PR TITLE
Import and validate schemas

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,6 +16,7 @@ jobs:
 
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         python-version: ["3.8", "3.9", "3.10", "3.11"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,8 @@ classifiers = [
   "Programming Language :: Python :: Implementation :: PyPy",
 ]
 dependencies = [
-  "dataclasses-json"
+  "dataclasses-json",
+  "jsonschema"
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ classifiers = [
 ]
 dependencies = [
   "dataclasses-json",
+  "importlib_resources",
   "jsonschema"
 ]
 

--- a/scripts/update_schemas
+++ b/scripts/update_schemas
@@ -1,0 +1,28 @@
+#!/usr/bin/env Rscript
+root <- here::here()
+
+outpack_branch <- "main"
+url <- "https://github.com/mrc-ide/outpack"
+tmp <- tempfile()
+repo <- gert::git_clone(url, tmp, outpack_branch)
+
+dest <- file.path(root, "src/outpack/schema/outpack")
+unlink(dest, recursive = TRUE)
+
+sha <- gert::git_info(tmp)$commit
+schema_version <-
+  jsonlite::read_json(file.path(tmp, "schema", "config.json"))$version
+
+fs::dir_copy(file.path(tmp, "schema"), dest)
+writeLines(c("# Imported from outpack",
+             "",
+             sprintf("* Schema version %s", schema_version),
+             sprintf("* Imported on %s", Sys.time()),
+             sprintf("* From outpack @ %s (%s)", sha, outpack_branch),
+             "",
+             "Do not make changes to files here, they will be overwritten",
+             "Run ./scripts/update_schemas to update"),
+           file.path(dest, "README.md"))
+file.create(file.path(dest, "__init__.py"))
+
+message(sprintf("Wrote schemas to '%s'", dest))

--- a/src/outpack/schema/__init__.py
+++ b/src/outpack/schema/__init__.py
@@ -1,0 +1,33 @@
+import json
+import os
+import os.path
+
+import importlib_resources
+from jsonschema import Draft7Validator
+from referencing import Registry, Resource
+
+
+def validate(instance, schema_name):
+    root = os.path.dirname(schema_name)
+
+    def retrieve(path):
+        return retrieve_from_filesystem(os.path.join(root, path))
+
+    schema = json.loads(read_schema(schema_name))
+    validator = Draft7Validator(schema, registry=Registry(retrieve=retrieve))
+    validator.validate(instance)
+
+
+def retrieve_from_filesystem(path: str):
+    contents = json.loads(read_schema(path))
+    return Resource.from_contents(contents)
+
+
+def outpack_schema_version():
+    data = read_schema("outpack/config.json")
+    return json.loads(data)["version"]
+
+
+def read_schema(name):
+    schema = importlib_resources.files("outpack.schema").joinpath(name)
+    return schema.read_text()

--- a/src/outpack/schema/outpack/README.md
+++ b/src/outpack/schema/outpack/README.md
@@ -1,0 +1,8 @@
+# Imported from outpack
+
+* Schema version 0.1.0
+* Imported on 2023-08-11 10:21:50.620608
+* From outpack @ e03fbf2caff18320132ca2a76d864b1b7f3b99c0 (main)
+
+Do not make changes to files here, they will be overwritten
+Run ./scripts/update_schemas to update

--- a/src/outpack/schema/outpack/config.json
+++ b/src/outpack/schema/outpack/config.json
@@ -1,0 +1,70 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "Outpack configuration schema",
+    "description": "Common configuration settings. Implementations may add additional properties, but these are the core.",
+    "version": "0.1.0",
+
+    "type": "object",
+
+    "properties": {
+        "schema_version": {
+            "description": "Schema version, used to manage migrations",
+            "type": "string",
+            "pattern": "^[0-9]+\\.[0-9]+\\.[0-9]+$"
+        },
+
+        "core": {
+            "type": "object",
+            "properties": {
+                "path_archive": {
+                    "type": ["null", "string"]
+                },
+                "use_file_store": {
+                    "type": "boolean"
+                },
+                "require_complete_tree": {
+                    "type": "boolean"
+                },
+                "hash_algorithm": {
+                    "enum": ["md5", "sha1", "sha256", "sha384", "sha512"]
+                }
+            },
+            "required": ["path_archive", "use_file_store", "hash_algorithm"],
+            "additionalProperties": false
+        },
+
+        "logging": {
+            "type": "object",
+            "properties": {
+                "threshold": {
+                    "enum": ["info", "debug", "trace"]
+                },
+                "console": {
+                    "type": "boolean"
+                }
+            },
+            "required": ["threshold", "console"]
+        },
+
+        "location": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "name": {
+                        "type": "string"
+                    },
+                    "type": {
+                        "type": "string"
+                    },
+                    "args": {
+                        "type": "object"
+                    }
+                },
+                "required": ["name", "type", "args"]
+            }
+        }
+    },
+
+    "required": ["schema_version", "core", "location"]
+}

--- a/src/outpack/schema/outpack/git.json
+++ b/src/outpack/schema/outpack/git.json
@@ -1,0 +1,23 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "Outpack git information",
+    "description": "Information about source versioning with git",
+    "version": "0.1.0",
+
+    "type": "object",
+    "properties": {
+        "sha": {
+            "type": "string",
+            "pattern": "^[0-9a-f]+$"
+        },
+        "branch": {
+            "type": "string"
+        },
+        "url": {
+            "type": "array",
+            "items": {
+                "type": "string"
+            }
+        }
+    }
+}

--- a/src/outpack/schema/outpack/hash.json
+++ b/src/outpack/schema/outpack/hash.json
@@ -1,0 +1,9 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "File hash",
+    "description": "A hash of a file, including the algorithm name (e.g., md5, sha256)",
+    "version": "0.1.0",
+
+    "type": "string",
+    "pattern": "^(md5|sha1|sha256|sha384|sha512):([0-9a-f]{16,})$"
+}

--- a/src/outpack/schema/outpack/location.json
+++ b/src/outpack/schema/outpack/location.json
@@ -1,0 +1,29 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "outpack location download schema",
+    "description": "Information about where a packet comes from",
+    "version": "0.1.0",
+
+    "type": "object",
+    "properties": {
+        "schema_version": {
+            "description": "Schema version, used to manage migrations",
+            "type": "string",
+            "pattern": "^[0-9]+\\.[0-9]+\\.[0-9]+$"
+        },
+
+        "packet": {
+            "$ref": "packet-id.json"
+        },
+
+        "time": {
+            "description": "Time that the packet was imported, in seconds since 1970-01-01",
+            "type": "number"
+        },
+
+        "hash": {
+            "$ref": "hash.json"
+        }
+    },
+    "required": ["schema_version", "packet", "time", "hash"]
+}

--- a/src/outpack/schema/outpack/metadata.json
+++ b/src/outpack/schema/outpack/metadata.json
@@ -1,0 +1,125 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "Outpack metadata schema",
+    "description": "This is the minimal schema, it is expected that implementations will want and need additional fields throughout",
+    "version": "0.1.0",
+
+    "type": "object",
+    "properties": {
+        "schema_version": {
+            "description": "Schema version, used to manage migrations",
+            "type": "string",
+            "pattern": "^[0-9]+\\.[0-9]+\\.[0-9]+$"
+        },
+
+        "id": {
+            "$ref": "packet-id.json"
+        },
+
+        "name": {
+            "description": "Packet name. No restrictions on contents",
+            "type": "string"
+        },
+
+        "parameters": {
+            "description": "Packet parameters, used when running and for querying. Parameters may only be simple types",
+            "oneOf": [
+                {
+                    "type": "null"
+                },
+                {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": ["boolean", "number", "string"]
+                    }
+                }
+            ]
+        },
+
+        "time": {
+            "description": "Information about the running time",
+            "start": {
+                "description": "Time that the report was started, in seconds since 1970-01-01",
+                "type": "number"
+            },
+            "end": {
+                "description": "Time that the report was completed, in seconds since 1970-01-01",
+                "type": "number"
+            },
+            "required": ["start", "end"],
+            "additionalProperties": {
+                "type": "number"
+            }
+        },
+
+        "files": {
+            "description": "Manifest of files present in this packet",
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "path": {
+                        "description": "The path of the file",
+                        "type": "string"
+                    },
+                    "hash": {
+                        "$ref": "hash.json"
+                    },
+                    "size": {
+                        "description": "The file size, in bytes",
+                        "type": "number"
+                    }
+                },
+                "required": ["path", "hash", "size"]
+            }
+        },
+
+        "depends": {
+            "description": "Information on dependencies",
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "packet": {
+                        "$ref": "packet-id.json"
+                    },
+                    "query": {
+                        "type": "string"
+                    },
+                    "files": {
+                        "type": "array",
+                        "minItems": 1,
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "here": {
+                                    "description": "The path of the file in this packet",
+                                    "type": "string"
+                                },
+                                "there": {
+                                    "description": "The path of the file within the upstream packet",
+                                    "type": "string"
+                                }
+                            },
+                            "required": ["here", "there"]
+                        }
+                    }
+                },
+                "required": ["packet", "query", "files"]
+            }
+        },
+
+        "custom": {
+            "description": "Optional custom metadata, grouped under application keys",
+            "type": ["null", "object"]
+        },
+
+        "git": {
+            "oneOf": [
+                { "type": "null" },
+                { "$ref": "git.json" }
+            ]
+        }
+    },
+    "required": ["schema_version", "id", "name", "parameters", "time", "files", "depends", "custom", "git"]
+}

--- a/src/outpack/schema/outpack/packet-id.json
+++ b/src/outpack/schema/outpack/packet-id.json
@@ -1,0 +1,9 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "Outpack packet id",
+    "description": "A globally unique identifier for any packet, composed of an encoded date (to millisecond accuracy) and random bytes",
+    "version": "0.1.0",
+
+    "type": "string",
+    "pattern": "^([0-9]{8}-[0-9]{6})-([0-9a-f]{8})$"
+}

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -1,0 +1,30 @@
+import json
+
+import pytest
+from jsonschema.exceptions import ValidationError
+
+from outpack.schema import outpack_schema_version, read_schema, validate
+
+
+def test_can_read_schema():
+    assert isinstance(read_schema("outpack/packet-id.json"), str)
+
+
+def test_can_validate_simple_schema():
+    validate("20230807-152345-0e0662d0", "outpack/packet-id.json")
+    with pytest.raises(ValidationError):
+        validate("20230807-152345-0e0662d", "outpack/packet-id.json")
+
+
+def test_can_validate_referenced_schemas():
+    p = "example/.outpack/location/local/20230807-152344-ee606dce"
+    with open(p) as f:
+        loc = json.load(f)
+    validate(loc, "outpack/location.json")
+    loc["packet"] = "yes"
+    with pytest.raises(ValidationError):
+        validate(loc, "outpack/location.json")
+
+
+def test_can_get_schema_version():
+    assert outpack_schema_version() == "0.1.0"


### PR DESCRIPTION
This PR uses the current "best practice" way of referencing files from within the installed packages, using importlib_resources (which is a backport of importlib.resources that will work for python 3.8), along with the current way of reading nested schemas. This is different on both counts to the implementation in mrc-ide/outpack-py, and the bulk of the PR there that I started (see https://github.com/mrc-ide/outpack-py/pull/5).

We don't use these anywhere yet because we never write json (we barely read it) but you'll need this for adding and removing locations from the configuration as you'll need to write the json there.

I've gone with a structure `schema/outpack/<name>.json` so that we can put the files for our own schemas at another subdirectory; this keeps the imported stuff separate. I've copied over the import script verbatim from the R version, but at some point we could replace this with a python or bash version