### PR TITLE
Add basic index

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,7 @@ test = "pytest {args:tests}"
 test-cov = "coverage run -m pytest {args:tests}"
 cov-report = [
   "- coverage combine",
-  "coverage report",
+  "coverage report --show-missing",
 ]
 cov = [
   "test-cov",

--- a/src/outpack/index.py
+++ b/src/outpack/index.py
@@ -1,0 +1,68 @@
+import pathlib
+from dataclasses import dataclass
+from typing import List
+
+from outpack.metadata import read_metadata_core, read_packet_location
+
+
+@dataclass
+class IndexData:
+    metadata: dict
+    location: dict
+    unpacked: List[str]
+
+    @staticmethod
+    def new():
+        return IndexData({}, {}, [])
+
+
+class Index:
+    def __init__(self, path):
+        self._path = pathlib.Path(path)
+        self.data = IndexData.new()
+
+    def rebuild(self):
+        self.data = index_update(self._path, IndexData.new())
+        return self
+
+    def refresh(self):
+        self.data = index_update(self._path, self.data)
+        return self
+
+    def metadata(self, id):
+        if id in self.data.metadata:
+            return self.data.metadata[id]
+        return self.refresh().data.metadata[id]
+
+    def location(self, name):
+        return self.refresh().data.location[name]
+
+    def unpacked(self):
+        return self.refresh().data.unpacked
+
+
+def index_update(path_root, data):
+    data.metadata = read_metadata(path_root, data.metadata)
+    data.location = read_locations(path_root, data.location)
+    data.unpacked = sorted(data.location["local"].keys())
+    return data
+
+
+def read_metadata(path_root, data):
+    path = path_root / ".outpack" / "metadata"
+    for p in path.iterdir():
+        if p.name not in data:
+            data[p.name] = read_metadata_core(p)
+    return data
+
+
+def read_locations(path_root, data):
+    path = path_root / ".outpack" / "location"
+    for loc in path.iterdir():
+        if loc.name not in data:
+            data[loc.name] = {}
+        d = data[loc.name]
+        for p in loc.iterdir():
+            if p.name not in d:
+                d[p.name] = read_packet_location(p)
+    return data

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -1,0 +1,39 @@
+import os
+import shutil
+
+import pytest
+
+from outpack.index import Index
+from outpack.metadata import read_metadata_core
+
+
+def test_can_create_index():
+    idx = Index("example")
+    packet = "20230807-152344-ee606dce"
+    expected = read_metadata_core("example/.outpack/metadata/" + packet)
+    ids = sorted(os.listdir("example/.outpack/metadata"))
+    # First read from disk:
+    assert idx.metadata(packet) == expected
+    # Second from cache:
+    assert idx.metadata(packet) == expected
+    assert len(idx.data.metadata) == 5
+    assert "local" in idx.data.location
+    assert len(idx.data.location) == 1
+    assert idx.data.metadata.keys() == idx.data.location["local"].keys()
+    assert idx.data.unpacked == ids
+    assert idx.location("local") == idx.data.location["local"]
+    assert idx.unpacked() == ids
+
+
+def test_rebuild_can_pick_up_deletions(tmp_path):
+    shutil.copytree("example", tmp_path, dirs_exist_ok=True)
+    idx1 = Index(tmp_path)
+    idx2 = Index(tmp_path)
+    packet = "20230807-152344-ee606dce"
+    assert idx1.refresh()
+    os.remove(tmp_path / ".outpack" / "metadata" / packet)
+    os.remove(tmp_path / ".outpack" / "location" / "local" / packet)
+    idx2.rebuild()
+    assert idx1.metadata(packet).id == packet
+    with pytest.raises(KeyError):
+        idx2.metadata(packet)


### PR DESCRIPTION
This PR adds support for a cacheable (though currently not cached) index into the outpack metadata store. This is needed in order to support things like search. In orderly2 all reads of the core (vs extended) metadata goes through this index.