### PR TITLE
Implement basic init method

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,7 @@ test = "pytest {args:tests}"
 test-cov = "coverage run -m pytest {args:tests}"
 cov-report = [
   "- coverage combine",
-  "coverage report",
+  "coverage report --show-missing",
 ]
 cov = [
   "test-cov",

--- a/src/outpack/config.py
+++ b/src/outpack/config.py
@@ -78,7 +78,7 @@ class Config:
             "sha256", path_archive, use_file_store, require_complete_tree
         )
         local = Location("local", "local")
-        return Config(version, core, [local])
+        return Config(version, core, {"local": local})
 
 
 def _config_path(root_path):

--- a/src/outpack/config.py
+++ b/src/outpack/config.py
@@ -4,11 +4,18 @@ from typing import Dict, Optional
 
 from dataclasses_json import config, dataclass_json
 
+from outpack.schema import outpack_schema_version
+
 
 def read_config(root_path):
     with open(_config_path(root_path)) as f:
         s = f.read()
     return Config.from_json(s.strip())
+
+
+def write_config(config, root_path):
+    with open(_config_path(root_path), "w") as f:
+        f.write(config.to_json())
 
 
 def _encode_location_dict(d):
@@ -55,6 +62,23 @@ class Config:
             encoder=_encode_location_dict, decoder=_decode_location_dict
         )
     )
+
+    @staticmethod
+    def new(
+        *,
+        path_archive="archive",
+        use_file_store=False,
+        require_complete_tree=False,
+    ):
+        if path_archive is None and not use_file_store:
+            msg = "If 'path_archive' is None, 'use_file_store' must be True"
+            raise Exception(msg)
+        version = outpack_schema_version()
+        core = ConfigCore(
+            "sha256", path_archive, use_file_store, require_complete_tree
+        )
+        local = Location("local", "local")
+        return Config(version, core, [local])
 
 
 def _config_path(root_path):

--- a/src/outpack/init.py
+++ b/src/outpack/init.py
@@ -46,8 +46,11 @@ def _validate_same_core_configuration(now, then):
         return
     a = then.to_dict()
     b = now.to_dict()
-    err = [f"* '{f}' was {a[f]} but {b[f]} requested" for f in a.keys()
-           if a[f] != b[f]]
+    err = [
+        f"* '{f}' was {a[f]} but {b[f]} requested"
+        for f in a.keys()
+        if a[f] != b[f]
+    ]
     msg = "Trying to change configuration when re-initialising:\n" + "\n".join(
         err
     )

--- a/src/outpack/init.py
+++ b/src/outpack/init.py
@@ -1,0 +1,55 @@
+from pathlib import Path
+
+from outpack.config import Config, read_config, write_config
+
+
+def outpack_init(
+    path,
+    *,
+    path_archive="archive",
+    use_file_store=False,
+    require_complete_tree=False,
+):
+    path = Path(path)
+    if path.exists():
+        if not path.is_dir():
+            msg = f"Path '{path}' already exists but is not a directory"
+            raise Exception(msg)
+        # As in orderly2, there are unresolved questions about if we
+        # allow initialising an outpack root into an existing
+        # directory. Here, we'll allow it.
+
+    config = Config.new(
+        path_archive=path_archive,
+        use_file_store=use_file_store,
+        require_complete_tree=require_complete_tree,
+    )
+
+    path_outpack = path.joinpath(".outpack")
+
+    if path_outpack.exists():
+        _validate_same_configuration(config, read_config(path))
+    else:
+        path_outpack.mkdir(parents=True, exist_ok=True)
+        path_outpack.joinpath("metadata").mkdir(parents=True, exist_ok=True)
+        path_outpack.joinpath("location").mkdir(parents=True, exist_ok=True)
+        path_outpack.joinpath("location/local").mkdir(
+            parents=True, exist_ok=True
+        )
+        write_config(config, path)
+
+    return path
+
+
+def _validate_same_configuration(now, then):
+    if now.core == then.core:
+        return
+    err = [
+        f"* {f} was {getattr(then, f)} but {getattr(now, f)} requested"
+        for f in now.fields()
+        if getattr(now, f) != getattr(then, f)
+    ]
+    msg = "Trying to change configuration when re-initialising:\n" + "\n".join(
+        err
+    )
+    raise Exception(msg)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -35,8 +35,9 @@ def test_can_create_new_config():
     assert not cfg.core.use_file_store
     assert not cfg.core.require_complete_tree
     assert len(cfg.location) == 1
-    assert cfg.location[0].name == "local"
-    assert cfg.location[0].type == "local"
+    assert list(cfg.location.keys()) == ["local"]
+    assert cfg.location["local"].name == "local"
+    assert cfg.location["local"].type == "local"
 
 
 def test_can_validate_dependent_values_in_new_config():

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,4 +1,6 @@
-from outpack.config import Config, Location, read_config
+import pytest
+
+from outpack.config import Config, Location, read_config, write_config
 
 
 def test_can_read_config():
@@ -16,6 +18,30 @@ def test_can_read_config():
     assert local.args == {}
 
 
-def test_can_write_json():
+def test_can_write_json(tmp_path):
     cfg = read_config("example")
     assert Config.from_json(cfg.to_json()) == cfg
+
+    tmp_path.joinpath(".outpack").mkdir()
+    write_config(cfg, tmp_path)
+    assert read_config(tmp_path) == cfg
+
+
+def test_can_create_new_config():
+    cfg = Config.new()
+    assert cfg.schema_version == "0.1.0"
+    assert cfg.core.hash_algorithm == "sha256"
+    assert cfg.core.path_archive == "archive"
+    assert not cfg.core.use_file_store
+    assert not cfg.core.require_complete_tree
+    assert len(cfg.location) == 1
+    assert cfg.location[0].name == "local"
+    assert cfg.location[0].type == "local"
+
+
+def test_can_validate_dependent_values_in_new_config():
+    with pytest.raises(
+        Exception,
+        match="If 'path_archive' is None, 'use_file_store' must be True",
+    ):
+        Config.new(path_archive=None)

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1,0 +1,43 @@
+import pytest
+
+from outpack.config import read_config
+from outpack.init import outpack_init
+
+
+def test_can_create_new_repo(tmp_path):
+    path = outpack_init(tmp_path)
+    assert path.exists()
+    assert path.is_dir()
+    cfg = read_config(path)
+    assert cfg.core.hash_algorithm == "sha256"
+    assert cfg.core.path_archive == "archive"
+    assert not cfg.core.use_file_store
+    assert not cfg.core.require_complete_tree
+    assert len(cfg.location) == 1
+    assert list(cfg.location.keys()) == ["local"]
+
+
+def test_fail_to_create_with_error_if_path_exists(tmp_path):
+    root = tmp_path / "root"
+    root.touch()
+    with pytest.raises(Exception, match="Path '.+' already exists but is not a directory"):
+        outpack_init(root)
+
+
+def test_allow_reinitialising_with_same_options(tmp_path):
+    path1 = outpack_init(tmp_path, path_archive=None, use_file_store=True,
+                         require_complete_tree=True)
+    path2 = outpack_init(tmp_path, path_archive=None, use_file_store=True,
+                         require_complete_tree=True)
+    assert path1 == path2
+
+
+def test_require_same_options_if_reinitialising(tmp_path):
+    path1 = outpack_init(tmp_path)
+    with pytest.raises(Exception) as e:
+        outpack_init(tmp_path, path_archive=None, use_file_store=True,
+                     require_complete_tree=True)
+    assert "Trying to change configuration when re-initialising:" in str(e)
+    assert "* 'path_archive' was archive but None requested" in str(e)
+    assert "* 'require_complete_tree' was False but True requested" in str(e)
+    assert "* 'use_file_store' was False but True requested" in str(e)

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -20,23 +20,37 @@ def test_can_create_new_repo(tmp_path):
 def test_fail_to_create_with_error_if_path_exists(tmp_path):
     root = tmp_path / "root"
     root.touch()
-    with pytest.raises(Exception, match="Path '.+' already exists but is not a directory"):
+    with pytest.raises(
+        Exception, match="Path '.+' already exists but is not a directory"
+    ):
         outpack_init(root)
 
 
 def test_allow_reinitialising_with_same_options(tmp_path):
-    path1 = outpack_init(tmp_path, path_archive=None, use_file_store=True,
-                         require_complete_tree=True)
-    path2 = outpack_init(tmp_path, path_archive=None, use_file_store=True,
-                         require_complete_tree=True)
+    path1 = outpack_init(
+        tmp_path,
+        path_archive=None,
+        use_file_store=True,
+        require_complete_tree=True,
+    )
+    path2 = outpack_init(
+        tmp_path,
+        path_archive=None,
+        use_file_store=True,
+        require_complete_tree=True,
+    )
     assert path1 == path2
 
 
 def test_require_same_options_if_reinitialising(tmp_path):
-    path1 = outpack_init(tmp_path)
+    outpack_init(tmp_path)
     with pytest.raises(Exception) as e:
-        outpack_init(tmp_path, path_archive=None, use_file_store=True,
-                     require_complete_tree=True)
+        outpack_init(
+            tmp_path,
+            path_archive=None,
+            use_file_store=True,
+            require_complete_tree=True,
+        )
     assert "Trying to change configuration when re-initialising:" in str(e)
     assert "* 'path_archive' was archive but None requested" in str(e)
     assert "* 'require_complete_tree' was False but True requested" in str(e)


### PR DESCRIPTION
This duplicates the logic in the R version, allowing creating a new outpack root and re-initialising with the same options (so that this is something that can be done unconditionally).