### PR TITLE
Start and end a packet

### DIFF
--- a/scripts/update_schemas
+++ b/scripts/update_schemas
@@ -23,6 +23,5 @@ writeLines(c("# Imported from outpack",
              "Do not make changes to files here, they will be overwritten",
              "Run ./scripts/update_schemas to update"),
            file.path(dest, "README.md"))
-file.create(file.path(dest, "__init__.py"))
 
 message(sprintf("Wrote schemas to '%s'", dest))

--- a/src/outpack/metadata.py
+++ b/src/outpack/metadata.py
@@ -41,6 +41,7 @@ class PacketDepends:
 @dataclass_json()
 @dataclass
 class MetadataCore:
+    schema_version: str
     id: str  # noqa: A003
     name: str
     parameters: Dict[str, Union[bool, int, float, str]]
@@ -48,6 +49,7 @@ class MetadataCore:
     files: List[PacketFile]
     depends: List[PacketDepends]
     git: Optional[GitInfo]
+    custom: Optional[dict]
 
 
 @dataclass_json()

--- a/src/outpack/metadata.py
+++ b/src/outpack/metadata.py
@@ -6,7 +6,7 @@ from dataclasses_json import dataclass_json
 
 from outpack.hash import hash_file
 from outpack.ids import validate_outpack_id
-from outpack.tools import git_info
+from outpack.tools import GitInfo, git_info
 
 
 @dataclass_json()
@@ -20,7 +20,7 @@ class PacketFile:
     def from_file(directory, path, hash_algorithm):
         f = Path(directory).joinpath(path)
         s = f.stat().st_size
-        h = hash_file(f, hash_algorithm)
+        h = str(hash_file(f, hash_algorithm))
         return PacketFile(path, s, h)
 
 
@@ -39,14 +39,6 @@ class PacketDepends:
     files: List[PacketDependsPath]
 
 
-@dataclass_json
-@dataclass
-class GitInfo:
-    sha: str
-    branch: str
-    url: List[str]
-
-
 @dataclass_json()
 @dataclass
 class MetadataCore:
@@ -57,8 +49,6 @@ class MetadataCore:
     files: List[PacketFile]
     depends: List[PacketDepends]
     git: Optional[GitInfo]
-
-    @staticmethod
 
 
 @dataclass_json()

--- a/src/outpack/metadata.py
+++ b/src/outpack/metadata.py
@@ -1,12 +1,11 @@
 from dataclasses import dataclass
-from typing import Dict, List, Optional, Union
 from pathlib import Path
+from typing import Dict, List, Optional, Union
 
 from dataclasses_json import dataclass_json
 
 from outpack.hash import hash_file
-from outpack.ids import validate_outpack_id
-from outpack.tools import GitInfo, git_info
+from outpack.tools import GitInfo
 
 
 @dataclass_json()

--- a/src/outpack/metadata.py
+++ b/src/outpack/metadata.py
@@ -1,7 +1,12 @@
 from dataclasses import dataclass
 from typing import Dict, List, Optional, Union
+from pathlib import Path
 
 from dataclasses_json import dataclass_json
+
+from outpack.hash import hash_file
+from outpack.ids import validate_outpack_id
+from outpack.tools import git_info
 
 
 @dataclass_json()
@@ -10,6 +15,13 @@ class PacketFile:
     path: str
     size: float
     hash: str  # noqa: A003
+
+    @staticmethod
+    def from_file(directory, path, hash_algorithm):
+        f = Path(directory).joinpath(path)
+        s = f.stat().st_size
+        h = hash_file(f, hash_algorithm)
+        return PacketFile(path, s, h)
 
 
 @dataclass_json()
@@ -45,6 +57,8 @@ class MetadataCore:
     files: List[PacketFile]
     depends: List[PacketDepends]
     git: Optional[GitInfo]
+
+    @staticmethod
 
 
 @dataclass_json()

--- a/src/outpack/packet.py
+++ b/src/outpack/packet.py
@@ -3,14 +3,17 @@ import shutil
 import time
 
 from outpack.ids import outpack_id
-from outpack.hash import hash_data
+from outpack.hash import hash_string
 from outpack.metadata import PacketFile, MetadataCore, PacketLocation
+from outpack.root import Root
 from outpack.schema import validate
+from outpack.tools import git_info
+from outpack.util import all_normal_files
 
 
 class Packet:
     def __init__(self, root, path, name, parameters=None):
-        self.root = root
+        self.root = Root(root)
         self.path = Path(path)
         self.id = outpack_id()
         self.name = name
@@ -19,32 +22,27 @@ class Packet:
         self.files = []
         self.time = {"begin": time.time()}
         self.git = git_info(self.path)
+        self._complete = False
 
-    def _metadata():
+    def _metadata(self):
         return MetadataCore(self.id, self.name, self.parameters,
                             self.time, self.files, self.depends,
-                            self.git)        
+                            self.git)
 
     def end(self, *, insert=True):
-        if self.metadata:
+        if self._complete:
             msg = f"Packet {id} already ended"
             raise Exception(msg)
         self.time["end"] = time.time()
-        # TODO: need to be careful here, only want regular
-        # files. Later expand to remove many.
-        files = list(self.path.iterdir())
-        algorithm = self.root.config.core.hash_algorithm
-        self.files = [PacketFile.from_file(path, f, algorithm) for f in files]
-        meta = self._metadata()
+        hash_algorithm = self.root.config.core.hash_algorithm
+        self.files = [PacketFile.from_file(self.path, f, hash_algorithm)
+                      for f in all_normal_files(self.path)]
         if insert:
-            _insert(self.root, self.path, meta)
+            _insert(self.root, self.path, self._metadata())
         else:
-            _cancel(self.root, self.path, meta)
+            _cancel(self.root, self.path, self._metadata())
+        self._complete = True
 
-
-def packet_start(root, path, name, parameters=None):
-    return Packet(root, path, name, parameters)
-                 
 
 def create(root, path, id, name, parameters, time, files, depends):
     meta = create_metadata(path, id, name, parameters, time, files, depends,
@@ -63,16 +61,15 @@ def _insert(root, path, meta):
 
     if root.config.core.path_archive:
         dest = root.path / "archive" / meta.name / meta.id
-        dest.mkdir()
         for p in meta.files:
             p_dest = dest / p.path
-            p_dest.parent.mkdir(exist_ok=True)
+            p_dest.parent.mkdir(parents=True, exist_ok=True)
             shutil.copy(path / p.path, p_dest)
 
-    time <- Sys.time()
-    json = meta.to_json()
-    hash_meta <- hash_data(json, root.config.core.hash_algorithm)
-    path_meta = root.path / "metadata" / meta.id
+    json = meta.to_json(separators=(",", ":"))
+    hash_meta = hash_string(json, root.config.core.hash_algorithm)
+    path_meta = root.path / ".outpack" / "metadata" / meta.id
+    path_meta.parent.mkdir(parents=True, exist_ok=True)
     with open(path_meta, "w") as f:
         f.write(json)
 
@@ -80,13 +77,13 @@ def _insert(root, path, meta):
 
 
 def _cancel(root, path, meta):
-    pass
+    with path.joinpath("outpack.json").open("w") as f:
+        f.write(meta.to_json())
 
 
 def mark_known(root, packet_id, location, hash, time):
-    dat = PacketLocation(id, time, hash)
+    dat = PacketLocation(packet_id, time, hash)
     dest = root.path / ".outpack" / "location" / location / packet_id
-    dest.parent().mkdir(exists_ok=True)
+    dest.parent.mkdir(parents=True, exist_ok=True)
     with open(dest, "w") as f:
-        f.write(dat.to_json())
-
+        f.write(dat.to_json(separators=(",", ":")))

--- a/src/outpack/packet.py
+++ b/src/outpack/packet.py
@@ -1,0 +1,92 @@
+from pathlib import Path
+import shutil
+import time
+
+from outpack.ids import outpack_id
+from outpack.hash import hash_data
+from outpack.metadata import PacketFile, MetadataCore, PacketLocation
+from outpack.schema import validate
+
+
+class Packet:
+    def __init__(self, root, path, name, parameters=None):
+        self.root = root
+        self.path = Path(path)
+        self.id = outpack_id()
+        self.name = name
+        self.parameters = parameters or {}
+        self.depends = []
+        self.files = []
+        self.time = {"begin": time.time()}
+        self.git = git_info(self.path)
+
+    def _metadata():
+        return MetadataCore(self.id, self.name, self.parameters,
+                            self.time, self.files, self.depends,
+                            self.git)        
+
+    def end(self, *, insert=True):
+        if self.metadata:
+            msg = f"Packet {id} already ended"
+            raise Exception(msg)
+        self.time["end"] = time.time()
+        # TODO: need to be careful here, only want regular
+        # files. Later expand to remove many.
+        files = list(self.path.iterdir())
+        algorithm = self.root.config.core.hash_algorithm
+        self.files = [PacketFile.from_file(path, f, algorithm) for f in files]
+        meta = self._metadata()
+        if insert:
+            _insert(self.root, self.path, meta)
+        else:
+            _cancel(self.root, self.path, meta)
+
+
+def packet_start(root, path, name, parameters=None):
+    return Packet(root, path, name, parameters)
+                 
+
+def create(root, path, id, name, parameters, time, files, depends):
+    meta = create_metadata(path, id, name, parameters, time, files, depends,
+                           hash_algorithm)
+    insert(path, meta, root)
+
+
+def _insert(root, path, meta):
+    # check that we have not already inserted this packet; in R we
+    # look to see if it's unpacked but actually the issue is if it is
+    # present as metadata at all.
+    if root.config.core.use_file_store:
+        store = root.store
+        for p in meta.files:
+            store.put(path / p.path, p.hash)
+
+    if root.config.core.path_archive:
+        dest = root.path / "archive" / meta.name / meta.id
+        dest.mkdir()
+        for p in meta.files:
+            p_dest = dest / p.path
+            p_dest.parent.mkdir(exist_ok=True)
+            shutil.copy(path / p.path, p_dest)
+
+    time <- Sys.time()
+    json = meta.to_json()
+    hash_meta <- hash_data(json, root.config.core.hash_algorithm)
+    path_meta = root.path / "metadata" / meta.id
+    with open(path_meta, "w") as f:
+        f.write(json)
+
+    mark_known(root, meta.id, "local", hash_meta, time.time())
+
+
+def _cancel(root, path, meta):
+    pass
+
+
+def mark_known(root, packet_id, location, hash, time):
+    dat = PacketLocation(id, time, hash)
+    dest = root.path / ".outpack" / "location" / location / packet_id
+    dest.parent().mkdir(exists_ok=True)
+    with open(dest, "w") as f:
+        f.write(dat.to_json())
+

--- a/src/outpack/packet.py
+++ b/src/outpack/packet.py
@@ -6,7 +6,7 @@ from outpack.hash import hash_string
 from outpack.ids import outpack_id
 from outpack.metadata import MetadataCore, PacketFile, PacketLocation
 from outpack.root import Root
-from outpack.schema import validate
+from outpack.schema import outpack_schema_version, validate
 from outpack.tools import git_info
 from outpack.util import all_normal_files
 
@@ -20,8 +20,9 @@ class Packet:
         self.parameters = parameters or {}
         self.depends = []
         self.files = []
-        self.time = {"begin": time.time()}
+        self.time = {"start": time.time()}
         self.git = git_info(self.path)
+        self.custom = None
         self.metadata = None
 
     def end(self, *, insert=True):
@@ -35,6 +36,7 @@ class Packet:
             for f in all_normal_files(self.path)
         ]
         self.metadata = self._build_metadata()
+        validate(self.metadata.to_dict(), "outpack/metadata.json")
         if insert:
             _insert(self.root, self.path, self.metadata)
         else:
@@ -42,6 +44,7 @@ class Packet:
 
     def _build_metadata(self):
         return MetadataCore(
+            outpack_schema_version(),
             self.id,
             self.name,
             self.parameters,
@@ -49,6 +52,7 @@ class Packet:
             self.files,
             self.depends,
             self.git,
+            self.custom,
         )
 
 

--- a/src/outpack/packet.py
+++ b/src/outpack/packet.py
@@ -1,10 +1,10 @@
-from pathlib import Path
 import shutil
 import time
+from pathlib import Path
 
-from outpack.ids import outpack_id
 from outpack.hash import hash_string
-from outpack.metadata import PacketFile, MetadataCore, PacketLocation
+from outpack.ids import outpack_id
+from outpack.metadata import MetadataCore, PacketFile, PacketLocation
 from outpack.root import Root
 from outpack.schema import validate
 from outpack.tools import git_info
@@ -30,8 +30,10 @@ class Packet:
             raise Exception(msg)
         self.time["end"] = time.time()
         hash_algorithm = self.root.config.core.hash_algorithm
-        self.files = [PacketFile.from_file(self.path, f, hash_algorithm)
-                      for f in all_normal_files(self.path)]
+        self.files = [
+            PacketFile.from_file(self.path, f, hash_algorithm)
+            for f in all_normal_files(self.path)
+        ]
         self.metadata = self._build_metadata()
         if insert:
             _insert(self.root, self.path, self.metadata)
@@ -39,9 +41,15 @@ class Packet:
             _cancel(self.root, self.path, self.metadata)
 
     def _build_metadata(self):
-        return MetadataCore(self.id, self.name, self.parameters,
-                            self.time, self.files, self.depends,
-                            self.git)
+        return MetadataCore(
+            self.id,
+            self.name,
+            self.parameters,
+            self.time,
+            self.files,
+            self.depends,
+            self.git,
+        )
 
 
 def _insert(root, path, meta):
@@ -49,7 +57,6 @@ def _insert(root, path, meta):
     # look to see if it's unpacked but actually the issue is if it is
     # present as metadata at all.
     if root.config.core.use_file_store:
-        store = root.files
         for p in meta.files:
             root.files.put(path / p.path, p.hash)
 
@@ -70,7 +77,7 @@ def _insert(root, path, meta):
     mark_known(root, meta.id, "local", hash_meta, time.time())
 
 
-def _cancel(root, path, meta):
+def _cancel(_root, path, meta):
     with path.joinpath("outpack.json").open("w") as f:
         f.write(meta.to_json())
 

--- a/src/outpack/root.py
+++ b/src/outpack/root.py
@@ -1,0 +1,14 @@
+from pathlib import Path
+
+from outpack.config import read_config
+from outpack.filestore import FileStore
+
+
+class Root:
+    def __init__(self, path):
+        self.path = Path(path)
+        self.config = read_config(path)
+        if self.config.core.use_file_store:
+            self.files = FileStore(self.path / "files")
+        # self.index = 
+        

--- a/src/outpack/root.py
+++ b/src/outpack/root.py
@@ -2,13 +2,15 @@ from pathlib import Path
 
 from outpack.config import read_config
 from outpack.filestore import FileStore
+from outpack.index import Index
 
 
 class Root:
+    files = None
+
     def __init__(self, path):
         self.path = Path(path)
         self.config = read_config(path)
         if self.config.core.use_file_store:
             self.files = FileStore(self.path / "files")
-        # self.index = 
-        
+        self.index = Index(path)

--- a/src/outpack/schema/outpack/README.md
+++ b/src/outpack/schema/outpack/README.md
@@ -1,8 +1,8 @@
 # Imported from outpack
 
-* Schema version 0.1.0
-* Imported on 2023-08-11 10:21:50.620608
-* From outpack @ e03fbf2caff18320132ca2a76d864b1b7f3b99c0 (main)
+* Schema version 0.1.1
+* Imported on 2023-08-18 12:21:43.441626
+* From outpack @ ba2bb5bf44a56b3c0ce78128fa419375df109fe3 (main)
 
 Do not make changes to files here, they will be overwritten
 Run ./scripts/update_schemas to update

--- a/src/outpack/schema/outpack/README.md
+++ b/src/outpack/schema/outpack/README.md
@@ -1,7 +1,7 @@
 # Imported from outpack
 
 * Schema version 0.1.1
-* Imported on 2023-08-18 12:21:43.441626
+* Imported on 2023-08-18 12:32:31.652665
 * From outpack @ ba2bb5bf44a56b3c0ce78128fa419375df109fe3 (main)
 
 Do not make changes to files here, they will be overwritten

--- a/src/outpack/schema/outpack/config.json
+++ b/src/outpack/schema/outpack/config.json
@@ -2,17 +2,11 @@
     "$schema": "http://json-schema.org/draft-07/schema#",
     "title": "Outpack configuration schema",
     "description": "Common configuration settings. Implementations may add additional properties, but these are the core.",
-    "version": "0.1.0",
+    "version": "0.1.1",
 
     "type": "object",
 
     "properties": {
-        "schema_version": {
-            "description": "Schema version, used to manage migrations",
-            "type": "string",
-            "pattern": "^[0-9]+\\.[0-9]+\\.[0-9]+$"
-        },
-
         "core": {
             "type": "object",
             "properties": {
@@ -31,19 +25,6 @@
             },
             "required": ["path_archive", "use_file_store", "hash_algorithm"],
             "additionalProperties": false
-        },
-
-        "logging": {
-            "type": "object",
-            "properties": {
-                "threshold": {
-                    "enum": ["info", "debug", "trace"]
-                },
-                "console": {
-                    "type": "boolean"
-                }
-            },
-            "required": ["threshold", "console"]
         },
 
         "location": {
@@ -66,5 +47,5 @@
         }
     },
 
-    "required": ["schema_version", "core", "location"]
+    "required": ["core", "location"]
 }

--- a/src/outpack/schema/outpack/git.json
+++ b/src/outpack/schema/outpack/git.json
@@ -2,7 +2,7 @@
     "$schema": "http://json-schema.org/draft-07/schema#",
     "title": "Outpack git information",
     "description": "Information about source versioning with git",
-    "version": "0.1.0",
+    "version": "0.1.1",
 
     "type": "object",
     "properties": {

--- a/src/outpack/schema/outpack/hash.json
+++ b/src/outpack/schema/outpack/hash.json
@@ -2,7 +2,7 @@
     "$schema": "http://json-schema.org/draft-07/schema#",
     "title": "File hash",
     "description": "A hash of a file, including the algorithm name (e.g., md5, sha256)",
-    "version": "0.1.0",
+    "version": "0.1.1",
 
     "type": "string",
     "pattern": "^(md5|sha1|sha256|sha384|sha512):([0-9a-f]{16,})$"

--- a/src/outpack/schema/outpack/location.json
+++ b/src/outpack/schema/outpack/location.json
@@ -2,16 +2,10 @@
     "$schema": "http://json-schema.org/draft-07/schema#",
     "title": "outpack location download schema",
     "description": "Information about where a packet comes from",
-    "version": "0.1.0",
+    "version": "0.1.1",
 
     "type": "object",
     "properties": {
-        "schema_version": {
-            "description": "Schema version, used to manage migrations",
-            "type": "string",
-            "pattern": "^[0-9]+\\.[0-9]+\\.[0-9]+$"
-        },
-
         "packet": {
             "$ref": "packet-id.json"
         },
@@ -25,5 +19,5 @@
             "$ref": "hash.json"
         }
     },
-    "required": ["schema_version", "packet", "time", "hash"]
+    "required": ["packet", "time", "hash"]
 }

--- a/src/outpack/schema/outpack/metadata.json
+++ b/src/outpack/schema/outpack/metadata.json
@@ -2,7 +2,7 @@
     "$schema": "http://json-schema.org/draft-07/schema#",
     "title": "Outpack metadata schema",
     "description": "This is the minimal schema, it is expected that implementations will want and need additional fields throughout",
-    "version": "0.1.0",
+    "version": "0.1.1",
 
     "type": "object",
     "properties": {

--- a/src/outpack/schema/outpack/packet-id.json
+++ b/src/outpack/schema/outpack/packet-id.json
@@ -2,7 +2,7 @@
     "$schema": "http://json-schema.org/draft-07/schema#",
     "title": "Outpack packet id",
     "description": "A globally unique identifier for any packet, composed of an encoded date (to millisecond accuracy) and random bytes",
-    "version": "0.1.0",
+    "version": "0.1.1",
 
     "type": "string",
     "pattern": "^([0-9]{8}-[0-9]{6})-([0-9a-f]{8})$"

--- a/src/outpack/tools.py
+++ b/src/outpack/tools.py
@@ -1,5 +1,7 @@
 import pygit2
 
+from outpack.metadata import GitInfo
+
 
 def git_info(path):
     repo = pygit2.discover_repository(path)
@@ -9,4 +11,4 @@ def git_info(path):
     sha = str(repo.head.target)
     branch = repo.head.shorthand
     url = [x.url for x in repo.remotes]
-    return {"sha": sha, "branch": branch, "url": url}
+    return GitInfo(sha, branch, url)

--- a/src/outpack/tools.py
+++ b/src/outpack/tools.py
@@ -1,7 +1,7 @@
 from dataclasses import dataclass
-import pygit2
 from typing import List
 
+import pygit2
 from dataclasses_json import dataclass_json
 
 

--- a/src/outpack/tools.py
+++ b/src/outpack/tools.py
@@ -1,6 +1,16 @@
+from dataclasses import dataclass
 import pygit2
+from typing import List
 
-from outpack.metadata import GitInfo
+from dataclasses_json import dataclass_json
+
+
+@dataclass_json
+@dataclass
+class GitInfo:
+    sha: str
+    branch: str
+    url: List[str]
 
 
 def git_info(path):

--- a/src/outpack/util.py
+++ b/src/outpack/util.py
@@ -26,3 +26,9 @@ def time_to_num(x):
 
 def num_to_time(x):
     return datetime.datetime.fromtimestamp(x, datetime.timezone.utc)
+
+
+def all_normal_files(path):
+    return [str(p.relative_to(path))
+            for p in Path(path).rglob("*")
+            if not p.is_dir()]

--- a/src/outpack/util.py
+++ b/src/outpack/util.py
@@ -29,6 +29,8 @@ def num_to_time(x):
 
 
 def all_normal_files(path):
-    return [str(p.relative_to(path))
-            for p in Path(path).rglob("*")
-            if not p.is_dir()]
+    return [
+        str(p.relative_to(path))
+        for p in Path(path).rglob("*")
+        if not p.is_dir()
+    ]

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -29,7 +29,7 @@ def test_can_write_json(tmp_path):
 
 def test_can_create_new_config():
     cfg = Config.new()
-    assert cfg.schema_version == "0.1.0"
+    assert cfg.schema_version == "0.1.1"
     assert cfg.core.hash_algorithm == "sha256"
     assert cfg.core.path_archive == "archive"
     assert not cfg.core.use_file_store

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -58,14 +58,9 @@ def test_can_read_location():
     )
 
 
-def test_can_add_metadata(tmp_path):
-    with tmp_path.joinpath("a").open("w") as f:
-        f.write("hello")
-    packet_id = "20230807-152344-ee606dce"
-    time = {"start": 1692030626.7001, "end": 1692030636}
-    files = ["a"]
-    depends = None
-    parameters = None
-    hash_algorithm = "md5"
-    meta = metadata_create(path, id, name, parameters, time, files, depends,
-                           hash_algorithm)
+def test_can_create_packet_file_metadata_from_file():
+    directory = "example/archive/data/20230807-152344-ee606dce"
+    path = "data.csv"
+    res = PacketFile.from_file(directory, path, "sha256")
+    h = "sha256:2a85eb5a027c8d2255e672d1592cc38c82cc0b08279b545a573ceccce9eb27cd"
+    assert res == PacketFile(path, 21, h)

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -56,3 +56,16 @@ def test_can_read_location():
         d.hash
         == "sha256:94809b0a23e2e1986304f112726ff20401000d51026f8fa85c7501ecd340b323"
     )
+
+
+def test_can_add_metadata(tmp_path):
+    with tmp_path.joinpath("a").open("w") as f:
+        f.write("hello")
+    packet_id = "20230807-152344-ee606dce"
+    time = {"start": 1692030626.7001, "end": 1692030636}
+    files = ["a"]
+    depends = None
+    parameters = None
+    hash_algorithm = "md5"
+    meta = metadata_create(path, id, name, parameters, time, files, depends,
+                           hash_algorithm)

--- a/tests/test_packet.py
+++ b/tests/test_packet.py
@@ -17,7 +17,7 @@ def test_can_add_simple_packet(tmp_path):
     p = Packet(root, src, "data")
     p.end()
 
-    assert type(p.id) == str
+    assert isinstance(p.id, str)
     assert p.name == "data"
     assert p.parameters == {}
     assert p.depends == []

--- a/tests/test_packet.py
+++ b/tests/test_packet.py
@@ -1,16 +1,99 @@
+import pytest
+
 from outpack.init import outpack_init
 from outpack.packet import Packet
+from outpack.root import Root
 
 
+def test_can_add_simple_packet(tmp_path):
+    root = tmp_path / "root"
+    src = tmp_path / "src"
+    outpack_init(root)
 
-# def test_can_add_metadata(tmp_path):
-#     with tmp_path.joinpath("a").open("w") as f:
-#         f.write("hello")
-#     packet_id = "20230807-152344-ee606dce"
-#     time = {"start": 1692030626.7001, "end": 1692030636}
-#     files = ["a"]
-#     depends = None
-#     parameters = None
-#     hash_algorithm = "md5"
-#     meta = metadata_create(path, id, name, parameters, time, files, depends,
-#                            hash_algorithm)
+    src.mkdir(parents=True, exist_ok=True)
+    with src.joinpath("a").open("w") as f:
+        f.write("hello")
+
+    p = Packet(root, src, "data")
+    p.end()
+
+    assert type(p.id) == str
+    assert p.name == "data"
+    assert p.parameters == {}
+    assert p.depends == []
+    assert len(p.files) == 1
+    assert p.files[0].path == "a"
+    assert list(p.time.keys()) == ["begin", "end"]
+    assert p.git == None
+
+    r = Root(root)
+    assert r.index.unpacked() == [p.id]
+    assert r.index.metadata(p.id) == p.metadata
+    assert (root / "archive" / "data" / p.id / "a").exists()
+
+
+def test_can_add_packet_to_store(tmp_path):
+    root = tmp_path / "root"
+    src = tmp_path / "src"
+    outpack_init(root, use_file_store=True, path_archive=None)
+
+    src.mkdir(parents=True, exist_ok=True)
+    with src.joinpath("a").open("w") as f:
+        f.write("hello")
+    with src.joinpath("b").open("w") as f:
+        f.write("goodbye")
+
+    p = Packet(root, src, "data")
+    p.end()
+
+    assert len(p.files) == 2
+
+    r = Root(root)
+    assert len(r.files.ls()) == 2
+    assert sorted([str(h) for h in r.files.ls()]) == sorted([f.hash for f in p.files])
+
+
+def test_cant_end_packet_twice(tmp_path):
+    root = tmp_path / "root"
+    src = tmp_path / "src"
+    outpack_init(root, use_file_store=True, path_archive=None)
+    src.mkdir(parents=True, exist_ok=True)
+    p = Packet(root, src, "data")
+    p.end()
+    with pytest.raises(Exception, match="Packet '.+' already ended"):
+        p.end()
+
+
+def test_can_cancel_packet(tmp_path):
+    root = tmp_path / "root"
+    src = tmp_path / "src"
+    outpack_init(root)
+
+    src.mkdir(parents=True, exist_ok=True)
+    with src.joinpath("a").open("w") as f:
+        f.write("hello")
+
+    p = Packet(root, src, "data")
+    p.end(insert=False)
+
+    r = Root(root)
+    assert len(r.index.unpacked()) == 0
+    assert src.joinpath("outpack.json").exists()
+
+
+def test_can_insert_a_packet_into_existing_root(tmp_path):
+    root = tmp_path / "root"
+    src = tmp_path / "src"
+    outpack_init(root)
+
+    src.mkdir(parents=True, exist_ok=True)
+    with src.joinpath("a").open("w") as f:
+        f.write("hello")
+
+    p1 = Packet(root, src, "data")
+    p1.end()
+    p2 = Packet(root, src, "data")
+    p2.end()
+
+    r = Root(root)
+    assert r.index.unpacked() == [p1.id, p2.id]

--- a/tests/test_packet.py
+++ b/tests/test_packet.py
@@ -1,0 +1,16 @@
+from outpack.init import outpack_init
+from outpack.packet import Packet
+
+
+
+# def test_can_add_metadata(tmp_path):
+#     with tmp_path.joinpath("a").open("w") as f:
+#         f.write("hello")
+#     packet_id = "20230807-152344-ee606dce"
+#     time = {"start": 1692030626.7001, "end": 1692030636}
+#     files = ["a"]
+#     depends = None
+#     parameters = None
+#     hash_algorithm = "md5"
+#     meta = metadata_create(path, id, name, parameters, time, files, depends,
+#                            hash_algorithm)

--- a/tests/test_packet.py
+++ b/tests/test_packet.py
@@ -24,7 +24,7 @@ def test_can_add_simple_packet(tmp_path):
     assert len(p.files) == 1
     assert p.files[0].path == "a"
     assert list(p.time.keys()) == ["begin", "end"]
-    assert p.git == None
+    assert p.git is None
 
     r = Root(root)
     assert r.index.unpacked() == [p.id]
@@ -50,7 +50,9 @@ def test_can_add_packet_to_store(tmp_path):
 
     r = Root(root)
     assert len(r.files.ls()) == 2
-    assert sorted([str(h) for h in r.files.ls()]) == sorted([f.hash for f in p.files])
+    assert sorted([str(h) for h in r.files.ls()]) == sorted(
+        [f.hash for f in p.files]
+    )
 
 
 def test_cant_end_packet_twice(tmp_path):

--- a/tests/test_packet.py
+++ b/tests/test_packet.py
@@ -23,7 +23,7 @@ def test_can_add_simple_packet(tmp_path):
     assert p.depends == []
     assert len(p.files) == 1
     assert p.files[0].path == "a"
-    assert list(p.time.keys()) == ["begin", "end"]
+    assert list(p.time.keys()) == ["start", "end"]
     assert p.git is None
 
     r = Root(root)

--- a/tests/test_root.py
+++ b/tests/test_root.py
@@ -1,7 +1,7 @@
 from outpack.config import read_config
 from outpack.filestore import FileStore
-from outpack.init import outpack_init
 from outpack.index import Index
+from outpack.init import outpack_init
 from outpack.root import Root
 
 

--- a/tests/test_root.py
+++ b/tests/test_root.py
@@ -1,0 +1,20 @@
+from outpack.config import read_config
+from outpack.filestore import FileStore
+from outpack.init import outpack_init
+from outpack.index import Index
+from outpack.root import Root
+
+
+def test_can_open_existing_root():
+    r = Root("example")
+    assert r.config == read_config("example")
+    assert isinstance(r.files, FileStore)
+    assert isinstance(r.index, Index)
+
+
+def test_can_open_root_with_no_store(tmp_path):
+    outpack_init(tmp_path)
+    r = Root(tmp_path)
+    assert r.config == read_config(tmp_path)
+    assert r.files is None
+    assert isinstance(r.index, Index)

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -27,4 +27,4 @@ def test_can_validate_referenced_schemas():
 
 
 def test_can_get_schema_version():
-    assert outpack_schema_version() == "0.1.0"
+    assert outpack_schema_version() == "0.1.1"

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -1,6 +1,6 @@
 import pygit2
 
-from outpack.tools import git_info
+from outpack.tools import GitInfo, git_info
 
 
 def simple_git_example(path, remote=None):
@@ -31,13 +31,13 @@ def test_git_report_git_info_if_possible(tmp_path):
     res = git_info(tmp_path)
     # This default branch name won't be robust to changes in future
     # git versions
-    assert res == {"branch": "master", "sha": sha, "url": []}
+    assert res == GitInfo(branch="master", sha=sha, url=[])
 
 
 def test_git_report_single_url(tmp_path):
     simple_git_example(tmp_path, [("origin", "https://example.com/git")])
     res = git_info(tmp_path)
-    assert res["url"] == ["https://example.com/git"]
+    assert res.url == ["https://example.com/git"]
 
 
 def test_git_report_several_urls(tmp_path):
@@ -49,7 +49,7 @@ def test_git_report_several_urls(tmp_path):
         ],
     )
     res = git_info(tmp_path)
-    assert res["url"] == ["https://example.com/git", "https://example.com/git2"]
+    assert res.url == ["https://example.com/git", "https://example.com/git2"]
 
 
 def test_git_report_from_subdir(tmp_path):


### PR DESCRIPTION
This PR adds about the simplest copy of packet start/end/metadata write I can think of, while supporting all the keys bits we'll need. It could have been broken up a little as there are two things done here in addition:

* trivial Root object which holds all the bits that we need to push around at once
* update the schemas to 0.1.1

The actual packet workflow is most easily seen in tests where we start and end a packet. At present all files are included, later we'll expand to shadow the orderly2 options of immutable and ignored files.  The implementation actually follows very closely to the R version, with a mutable packet object that we'll pass about and update