### PR TITLE
Add basic search

### DIFF
--- a/src/outpack/ids.py
+++ b/src/outpack/ids.py
@@ -17,6 +17,10 @@ def outpack_id():
     return f"{iso_time_str(t)}-{fractional_to_bytes(t)}{rand}"
 
 
+def is_outpack_id(x: str):
+    return RE_ID.match(x)
+
+
 def validate_outpack_id(x: str):
     if not RE_ID.match(x):
         msg = f"Malformed id '{x}'"

--- a/src/outpack/search.py
+++ b/src/outpack/search.py
@@ -1,0 +1,60 @@
+from outpack.root import Root
+from outpack.search_options import SearchOptions
+from outpack.search_query import query_parse
+
+
+class QueryEnv:
+    def __init__(self, root, options):
+        self.index = QueryIndex(root, options)
+
+
+class QueryIndex:
+    root = None
+    index = None
+    options = None
+    _seen = None
+
+    def __init__(self, root, options):
+        self.root = root
+        if options.allow_remote:
+            msg = "Can't use 'allow_remote' in search yet"
+            raise NotImplementedError(msg)
+        ids = root.index.unpacked()
+        self.index = {i: root.index.metadata(i) for i in ids}
+        self.options = options
+        self._seen = {}
+
+
+def search(expr, *, options=None, root=None):
+    if options is None:
+        options = SearchOptions()
+    root = Root(root)
+    query = query_parse(expr)
+    env = QueryEnv(root, options)
+    return query_eval(query.expr, env)
+
+
+def query_eval(expr, env):
+    if expr.kind == "latest":
+        return query_eval_latest(expr, env)
+    elif expr.kind == "id":
+        return query_eval_id(expr, env)
+    else:
+        msg = "Unhandled expression [outpack bug - please report]"
+        raise NotImplementedError(msg)
+
+
+def query_eval_latest(query, env):
+    # Assertion here as a reminder we'll need to expand this.
+    assert len(query.args) == 0  # noqa: S101
+    candidates = env.index.index.keys()
+    if len(candidates) == 0:
+        return None
+    return max(candidates)
+
+
+def query_eval_id(query, env):
+    packet_id = query.args[0]
+    if packet_id not in env.index.index:
+        return None
+    return packet_id

--- a/src/outpack/search_query.py
+++ b/src/outpack/search_query.py
@@ -1,0 +1,48 @@
+from dataclasses import dataclass
+from typing import List
+
+from outpack.ids import is_outpack_id
+
+
+class Query:
+    def __init__(self, expr):
+        self.expr = expr
+        self.is_single = True
+        self.parameters = []
+
+
+@dataclass
+class QueryComponent:
+    kind: str
+    expr: str
+    args: List[str]
+
+    def __init__(self, kind, expr, args):
+        self.kind = kind
+        self.expr = expr
+        self.args = args
+
+
+def query_parse_latest(expr):
+    return QueryComponent("latest", expr, [])
+
+
+def query_parse_id(expr):
+    return QueryComponent("id", expr, [expr])
+
+
+def query_parse(expr):
+    if expr == "latest":
+        expr = "latest()"
+    expr = query_parse_expr(expr)
+    return Query(expr)
+
+
+def query_parse_expr(expr):
+    if expr == "latest()":
+        return query_parse_latest(expr)
+    elif is_outpack_id(expr):
+        return query_parse_id(expr)
+    else:
+        msg = f"Unhandled query expression '{expr}'"
+        raise Exception(msg)

--- a/tests/test_ids.py
+++ b/tests/test_ids.py
@@ -1,6 +1,11 @@
 import pytest
 
-from outpack.ids import fractional_to_bytes, outpack_id, validate_outpack_id
+from outpack.ids import (
+    fractional_to_bytes,
+    is_outpack_id,
+    outpack_id,
+    validate_outpack_id,
+)
 
 
 def test_fractional_to_bytes():
@@ -14,9 +19,14 @@ def test_fractional_to_bytes():
 def test_outpack_id_creation():
     x = outpack_id()
     assert len(x) == 24
+    assert is_outpack_id(x)
 
 
 def test_outpack_id_can_be_validated():
-    validate_outpack_id("20230810-172859-6b0408e0")
+    id_ok = "20230810-172859-6b0408e0"
+    validate_outpack_id(id_ok)
+    assert is_outpack_id(id_ok)
+    id_err = "20230810-172859-6b0408e"
     with pytest.raises(Exception, match="Malformed id"):
-        validate_outpack_id("20230810-172859-6b0408e")
+        validate_outpack_id(id_err)
+    assert not is_outpack_id(id_err)

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -1,0 +1,35 @@
+import pytest
+
+from outpack.init import outpack_init
+from outpack.search import query_eval, search
+from outpack.search_options import SearchOptions
+from outpack.search_query import QueryComponent
+
+
+def test_can_do_simple_search():
+    assert search("latest", root="example") == "20230814-163026-ac5900c0"
+    assert (
+        search("20230807-152345-0e0662d0", root="example")
+        == "20230807-152345-0e0662d0"
+    )
+    assert search("20230807-152345-0e0662bb", root="example") is None
+
+
+def test_can_return_no_results_on_miss(tmp_path):
+    root = tmp_path / "root"
+    outpack_init(root)
+
+    assert search("latest", root=root) is None
+    assert search("20230807-152345-0e0662d0", root=root) is None
+
+
+def test_can_not_pass_remote_options():
+    with pytest.raises(NotImplementedError, match="Can't use 'allow_remote'"):
+        options = SearchOptions(allow_remote=True)
+        search("latest", root="example", options=options)
+
+
+def test_guard_aginst_new_expessions():
+    expr = QueryComponent("somethingelse", "expr", [])
+    with pytest.raises(NotImplementedError, match="Unhandled expression"):
+        query_eval(expr, None)

--- a/tests/test_search_query.py
+++ b/tests/test_search_query.py
@@ -1,0 +1,25 @@
+import pytest
+
+from outpack.search_query import Query, QueryComponent, query_parse
+
+
+def test_can_parse_simple_latest_query():
+    expr = query_parse("latest")
+    assert isinstance(expr, Query)
+    assert expr.is_single
+    assert expr.parameters == []
+    assert expr.expr == QueryComponent("latest", "latest()", [])
+
+
+def test_can_parse_simple_id_query():
+    x = "20230810-172859-6b0408e0"
+    expr = query_parse(x)
+    assert isinstance(expr, Query)
+    assert expr.is_single
+    assert expr.parameters == []
+    assert expr.expr == QueryComponent("id", x, [x])
+
+
+def test_can_not_parse_interesting_query():
+    with pytest.raises(Exception, match="Unhandled query expression"):
+        query_parse("latest(parameter:x == this:y)")


### PR DESCRIPTION
This adds the basic scaffolding for search, though it's so basic as to not really be very useful.

Currently allows `latest` (and `latest()`) and ids. But you can't even filter latest by name! Uses the same approach as orderly2 and sets up a little index that we can use for searching against.