### PR TITLE
Add simple check for immutable files

### DIFF
--- a/src/orderly/run.py
+++ b/src/orderly/run.py
@@ -19,9 +19,9 @@ def orderly_run(name, *, root=None, locate=True):
 
     packet = Packet(root, path_dest, name, id=packet_id, locate=False)
     try:
+        packet.mark_file_immutable("orderly.py")
         # TODO: mark the packet active while we run it
         # TODO: add custom orderly state into active packet
-        # TODO: mark the outpack.py file as immutable
         run_script(path_dest, "orderly.py")
     except Exception as error:
         _orderly_cleanup_failure(packet)

--- a/src/outpack/packet.py
+++ b/src/outpack/packet.py
@@ -39,7 +39,7 @@ class Packet:
         self.custom[key] = value
 
     def mark_file_immutable(self, path):
-        if not path in self._immutable:
+        if path not in self._immutable:
             self._immutable[path] = hash_file(self.path / path)
 
     def end(self, *, insert=True):

--- a/tests/test_packet.py
+++ b/tests/test_packet.py
@@ -171,3 +171,20 @@ def test_can_detect_modification_of_immutable_file(tmp_path):
         f.write("5,6\n")
     with pytest.raises(Exception, match="File was changed after being added"):
         p.end()
+
+
+def test_can_detect_modification_of_immutable_file_if_readded(tmp_path):
+    """Test that it is the _first_ addition of the hash that matters."""
+    root = tmp_path / "root"
+    src = tmp_path / "src"
+    outpack_init(root)
+    src.mkdir(parents=True, exist_ok=True)
+    p = Packet(root, src, "data")
+    with open(src / "data.csv", "w") as f:
+        f.write("a,b\n1,2\n3,4\n")
+    p.mark_file_immutable("data.csv")
+    with open(src / "data.csv", "a") as f:
+        f.write("5,6\n")
+    p.mark_file_immutable("data.csv")
+    with pytest.raises(Exception, match="File was changed after being added"):
+        p.end()


### PR DESCRIPTION
This was pretty simple actually - lets us mark files as immutable and then check that they are not deleted or changed when the packet is closed out.