### PR TITLE
mrc-4570: add support for artefacts

### DIFF
--- a/src/orderly/__init__.py
+++ b/src/orderly/__init__.py
@@ -1,3 +1,3 @@
-from orderly.core import resource
+from orderly.core import artefact, resource
 
-__all__ = ["resource"]
+__all__ = ["artefact", "resource"]

--- a/src/orderly/core.py
+++ b/src/orderly/core.py
@@ -1,4 +1,3 @@
-import os
 from dataclasses import dataclass
 from typing import List
 
@@ -31,12 +30,7 @@ def resource(files):
     Nothing, this is called for its side effects within a running packet
 
     """
-    if not isinstance(files, list):
-        files = [files]
-    for f in files:
-        if os.path.isabs(f):
-            msg = f"Expected resource path '{f}' to be a relative path"
-            raise Exception(msg)
+    files = util.relative_path_array(files, "resource")
     util.assert_file_exists(files)
     p = get_active_packet()
     src = p.packet.path if p else None
@@ -79,8 +73,8 @@ def artefact(name, files):
     Nothing, this is called for its side effects within a running packet
 
     """
-    if isinstance(files, str):
-        files = [files]
+    files = util.relative_path_array(files, "artefact")
     p = get_active_packet()
     if p:
         p.orderly.artefacts.append(Artefact(name, files))
+    return files

--- a/src/orderly/core.py
+++ b/src/orderly/core.py
@@ -1,7 +1,18 @@
 import os
+from dataclasses import dataclass
+from typing import List
+
+from dataclasses_json import dataclass_json
 
 from orderly.current import get_active_packet
 from outpack import util
+
+
+@dataclass_json()
+@dataclass
+class Artefact:
+    name: str = None
+    files: List[str] = None
 
 
 def resource(files):
@@ -36,3 +47,40 @@ def resource(files):
             p.packet.mark_file_immutable(f)
         p.orderly.resources += files_expanded
     return files_expanded
+
+
+def artefact(name, files):
+    """Declare an artefact.
+
+    By doing this you turn on a number of orderly features:
+
+    (1) Files that are artefacts will not be copied from the src
+    directory into the draft directory unless they are also listed as
+    a resource by 'orderly.resource'
+
+    (2) If your script fails to produce these files, then
+    `orderly.run` will fail, guaranteeing that your task really does
+    produce the things you need it do.
+
+    (3) Within the final metadata, your artefacts will have additional
+    metadata; the description that you provide and a grouping.
+
+    Parameters
+    ----------
+    description : str
+        The name of the artefact
+
+    files : str or [str]
+        The file, or array of files, that make up this artefact. These
+        are relative paths.
+
+    Returns
+    -------
+    Nothing, this is called for its side effects within a running packet
+
+    """
+    if isinstance(files, str):
+        files = [files]
+    p = get_active_packet()
+    if p:
+        p.orderly.artefacts.append(Artefact(name, files))

--- a/src/orderly/current.py
+++ b/src/orderly/current.py
@@ -1,6 +1,7 @@
 class OrderlyCustomMetadata:
     def __init__(self):
         self.resources = []
+        self.artefacts = []
 
 
 class RunningOrderlyPacket:

--- a/src/orderly/run.py
+++ b/src/orderly/run.py
@@ -65,11 +65,11 @@ def _copy_resources_implicit(src, dest):
 
 
 def _orderly_cleanup_success(packet, orderly):
-    missing = {}
+    missing = set()
     for artefact in orderly.artefacts:
         for path in artefact.files:
             if not packet.path.joinpath(path).exists():
-                missing += path
+                missing.add(path)
     if missing:
         missing = ", ".join(f"'{x}'" for x in sorted(missing))
         msg = f"Script did not produce the expected artefacts: {missing}"

--- a/src/orderly/run.py
+++ b/src/orderly/run.py
@@ -32,9 +32,11 @@ def orderly_run(name, *, root=None, locate=True):
         msg = "Running orderly report failed!"
         raise Exception(msg) from error
 
-    # TODO: This needs to be done within a try/catch block too to
-    # ensure that the failed metadata is written.
-    _orderly_cleanup_success(packet, orderly)
+    try:
+        _orderly_cleanup_success(packet, orderly)
+    except Exception:
+        _orderly_cleanup_failure(packet)
+        raise
     return packet_id
 
 

--- a/src/outpack/util.py
+++ b/src/outpack/util.py
@@ -90,3 +90,13 @@ def match_value(arg, choices, name):
         choices_str = "', '".join(choices)
         msg = f"{name} must be one of '{choices_str}'"
         raise Exception(msg)
+
+
+def relative_path_array(files, name):
+    if not isinstance(files, list):
+        files = [files]
+    for f in files:
+        if os.path.isabs(f):
+            msg = f"Expected {name} path '{f}' to be a relative path"
+            raise Exception(msg)
+    return files

--- a/tests/orderly/examples/artefact/orderly.py
+++ b/tests/orderly/examples/artefact/orderly.py
@@ -1,0 +1,8 @@
+import random
+
+import orderly
+
+d = [random.random() for _ in range(10)]  # noqa: S311
+orderly.artefact("Random numbers", "result.txt")
+with open("result.txt", "w") as f:
+    f.write("".join([str(x) + "\n" for x in d]))

--- a/tests/orderly/test_run.py
+++ b/tests/orderly/test_run.py
@@ -147,3 +147,19 @@ def test_can_run_example_with_artefact(tmp_path):
     }
     assert meta.custom == custom
     assert meta.git is None
+
+
+def test_can_error_if_artefacts_not_produced(tmp_path):
+    path = outpack_init(tmp_path)
+    path_src = path / "src" / "resource"
+    path_src.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copytree("tests/orderly/examples/resource", path_src)
+    res = orderly_run("resource", root=path)
+    with open(path_src / "orderly.py", "a") as f:
+        f.write("orderly.artefact('something', 'a')\n")
+    with pytest.raises(Exception, match="Script did not produce the expected artefacts: 'a'"):
+        orderly_run("resource", root=path)
+    with open(path_src / "orderly.py", "a") as f:
+        f.write("orderly.artefact('something else', ['c', 'b'])\n")
+    with pytest.raises(Exception, match="Script did not produce the expected artefacts: 'a', 'b', 'c'"):
+        orderly_run("resource", root=path)

--- a/tests/orderly/test_run.py
+++ b/tests/orderly/test_run.py
@@ -4,8 +4,8 @@ import pytest
 from orderly.run import _validate_src_directory, orderly_run
 
 from outpack.init import outpack_init
-from outpack.root import root_open
 from outpack.metadata import read_metadata_core
+from outpack.root import root_open
 
 
 ## We're going to need a small test helper module here at some point,
@@ -155,10 +155,12 @@ def test_can_error_if_artefacts_not_produced(tmp_path):
     path_src = path / "src" / "resource"
     path_src.parent.mkdir(parents=True, exist_ok=True)
     shutil.copytree("tests/orderly/examples/resource", path_src)
-    res = orderly_run("resource", root=path)
+    orderly_run("resource", root=path)
     with open(path_src / "orderly.py", "a") as f:
         f.write("orderly.artefact('something', 'a')\n")
-    with pytest.raises(Exception, match="Script did not produce the expected artefacts: 'a'"):
+    with pytest.raises(
+        Exception, match="Script did not produce the expected artefacts: 'a'"
+    ):
         orderly_run("resource", root=path)
     assert (tmp_path / "draft" / "resource").exists()
     contents = list((tmp_path / "draft" / "resource").iterdir())
@@ -169,5 +171,8 @@ def test_can_error_if_artefacts_not_produced(tmp_path):
     assert meta.custom == {}
     with open(path_src / "orderly.py", "a") as f:
         f.write("orderly.artefact('something else', ['c', 'b'])\n")
-    with pytest.raises(Exception, match="Script did not produce the expected artefacts: 'a', 'b', 'c'"):
+    with pytest.raises(
+        Exception,
+        match="Script did not produce the expected artefacts: 'a', 'b', 'c'",
+    ):
         orderly_run("resource", root=path)

--- a/tests/orderly/test_run.py
+++ b/tests/orderly/test_run.py
@@ -5,6 +5,7 @@ from orderly.run import _validate_src_directory, orderly_run
 
 from outpack.init import outpack_init
 from outpack.root import root_open
+from outpack.metadata import read_metadata_core
 
 
 ## We're going to need a small test helper module here at some point,
@@ -159,6 +160,13 @@ def test_can_error_if_artefacts_not_produced(tmp_path):
         f.write("orderly.artefact('something', 'a')\n")
     with pytest.raises(Exception, match="Script did not produce the expected artefacts: 'a'"):
         orderly_run("resource", root=path)
+    assert (tmp_path / "draft" / "resource").exists()
+    contents = list((tmp_path / "draft" / "resource").iterdir())
+    assert len(contents) == 1
+    assert contents[0].joinpath("outpack.json").exists()
+    meta = read_metadata_core(contents[0].joinpath("outpack.json"))
+    assert meta.name == "resource"
+    assert meta.custom == {}
     with open(path_src / "orderly.py", "a") as f:
         f.write("orderly.artefact('something else', ['c', 'b'])\n")
     with pytest.raises(Exception, match="Script did not produce the expected artefacts: 'a', 'b', 'c'"):

--- a/tests/orderly/test_run_metadata.py
+++ b/tests/orderly/test_run_metadata.py
@@ -56,3 +56,9 @@ def test_resource_requires_file_exists_with_packet(tmp_path):
             res = orderly.resource(["a"])
 
     assert active.resources == res
+
+
+def test_artefact_is_allowed_without_packet(tmp_path):
+    with transient_working_directory(tmp_path):
+        res = orderly.artefact("a", "b")
+    assert res == ["b"]


### PR DESCRIPTION
This PR adds basic support for artefacts in the python orderly/outpack implementation.

Directories are not expanded yet - I can do that here, or later. I'm still finding the test setup a bit tedious really, but that's mostly familiarity.

The other change here is to ensure we write out the metadata on cleanup failure.