### PR TITLE
mrc-4626: support for copying files out of outpack

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -139,7 +139,9 @@ ignore = [
   # Don't require docstrings everywhere for now
   "D100", "D101", "D102", "D103", "D104", "D105",
   # Ignore shadowing
-  "A002"
+  "A001", "A002",
+  # Allow print until we find the alternative to R's cli
+  "T201"
 ]
 unfixable = [
   # Don't touch unused imports

--- a/src/outpack/filestore.py
+++ b/src/outpack/filestore.py
@@ -23,6 +23,7 @@ class FileStore:
             msg = f"Hash '{hash}' not found in store"
             raise Exception(msg)
         os.makedirs(os.path.dirname(dst), exist_ok=True)
+        # todo - control over overwrite args needed.
         shutil.copyfile(src, dst)
 
     def exists(self, hash):

--- a/src/outpack/metadata.py
+++ b/src/outpack/metadata.py
@@ -51,6 +51,13 @@ class MetadataCore:
     git: Optional[GitInfo]
     custom: Optional[dict]
 
+    def file_hash(self, name):
+        for x in self.files:
+            if x.path == name:
+                return x.hash
+        msg = f"Packet {self.id} does not contain file '{name}'"
+        raise Exception(msg)
+
 
 @dataclass_json()
 @dataclass

--- a/src/outpack/root.py
+++ b/src/outpack/root.py
@@ -1,8 +1,10 @@
 import os
+import shutil
 from pathlib import Path
 
 from outpack.config import read_config
 from outpack.filestore import FileStore
+from outpack.hash import hash_file, hash_parse
 from outpack.index import Index
 from outpack.util import find_file_descend
 
@@ -16,6 +18,44 @@ class OutpackRoot:
         if self.config.core.use_file_store:
             self.files = FileStore(self.path / "files")
         self.index = Index(path)
+
+    def export_file(self, id, there, here, dest):
+        meta = self.index.metadata(id)
+        hash = meta.file_hash(there)
+        dest = Path(dest)
+        here_full = dest / here
+        if self.config.core.use_file_store:
+            self.files.get(hash, here_full)
+        else:
+            # consider starting from the case most likely to contain
+            # this hash, since we already know that it's 'id' unless
+            # it's corrupt - this is what the R version does (though
+            # it only does that).
+            src = self.find_file_by_hash(hash)
+            if not src:
+                msg = f"File not found in archive, or corrupt: {there}"
+                raise Exception(msg)
+            here_full.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copyfile(src, here_full)
+        return here
+
+    def find_file_by_hash(self, hash):
+        path_archive = self.path / self.config.core.path_archive
+        hash_parsed = hash_parse(hash)
+        for id in self.index.unpacked():
+            meta = self.index.metadata(id)
+            for f in meta.files:
+                if f.hash == hash:
+                    path = path_archive / meta.name / meta.id / f.path
+                    if hash_file(path, hash_parsed.algorithm) == hash_parsed:
+                        return path
+                    else:
+                        msg = (
+                            f"Rejecting file from archive '{f.path}'"
+                            f"in {meta.name}/{meta.id}"
+                        )
+                        print(msg)
+        return None
 
 
 def root_open(path, locate):

--- a/src/outpack/root.py
+++ b/src/outpack/root.py
@@ -31,31 +31,13 @@ class OutpackRoot:
             # this hash, since we already know that it's 'id' unless
             # it's corrupt - this is what the R version does (though
             # it only does that).
-            src = self.find_file_by_hash(hash)
+            src = find_file_by_hash(self, hash)
             if not src:
                 msg = f"File not found in archive, or corrupt: {there}"
                 raise Exception(msg)
             here_full.parent.mkdir(parents=True, exist_ok=True)
             shutil.copyfile(src, here_full)
         return here
-
-    def find_file_by_hash(self, hash):
-        path_archive = self.path / self.config.core.path_archive
-        hash_parsed = hash_parse(hash)
-        for id in self.index.unpacked():
-            meta = self.index.metadata(id)
-            for f in meta.files:
-                if f.hash == hash:
-                    path = path_archive / meta.name / meta.id / f.path
-                    if hash_file(path, hash_parsed.algorithm) == hash_parsed:
-                        return path
-                    else:
-                        msg = (
-                            f"Rejecting file from archive '{f.path}'"
-                            f"in {meta.name}/{meta.id}"
-                        )
-                        print(msg)
-        return None
 
 
 def root_open(path, locate):
@@ -78,3 +60,22 @@ def root_open(path, locate):
         msg = f"Did not find existing outpack root in '{path}'"
         raise Exception(msg)
     return OutpackRoot(path_outpack)
+
+
+def find_file_by_hash(root, hash):
+    path_archive = root.path / root.config.core.path_archive
+    hash_parsed = hash_parse(hash)
+    for id in root.index.unpacked():
+        meta = root.index.metadata(id)
+        for f in meta.files:
+            if f.hash == hash:
+                path = path_archive / meta.name / meta.id / f.path
+                if hash_file(path, hash_parsed.algorithm) == hash_parsed:
+                    return path
+                else:
+                    msg = (
+                        f"Rejecting file from archive '{f.path}'"
+                        f"in {meta.name}/{meta.id}"
+                    )
+                    print(msg)
+    return None

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -1,3 +1,5 @@
+import pytest
+
 from outpack.metadata import (
     PacketDependsPath,
     PacketFile,
@@ -64,3 +66,15 @@ def test_can_create_packet_file_metadata_from_file():
     res = PacketFile.from_file(directory, path, "sha256")
     h = "sha256:2a85eb5a027c8d2255e672d1592cc38c82cc0b08279b545a573ceccce9eb27cd"
     assert res == PacketFile(path, 21, h)
+
+
+def test_can_get_file_hash_from_metadata():
+    d = read_metadata_core("example/.outpack/metadata/20230807-152344-ee606dce")
+    expected = "sha256:2a85eb5a027c8d2255e672d1592cc38c82cc0b08279b545a573ceccce9eb27cd"
+    assert d.file_hash("data.csv") == expected
+
+
+def test_can_error_if_file_not_found_in_metadata():
+    d = read_metadata_core("example/.outpack/metadata/20230807-152344-ee606dce")
+    with pytest.raises(Exception, match="Packet .+ does not contain file 'f'"):
+        d.file_hash("f")


### PR DESCRIPTION
This is a prereq for the more generally useful copying, including that in dependencies.

I've gone with a free-function version of file_file_by_hash, so your PR should find this easy to pull in