### PR TITLE
Implement dependencies at the packet level

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,4 +42,6 @@ jobs:
       - name: Upload to Codecov
         uses: codecov/codecov-action@v3
         with:
-          fail_ci_if_error: true
+          # This can be useful, but the false positive rate is
+          # annoyingly high.
+          fail_ci_if_error: false

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -139,7 +139,7 @@ ignore = [
   # Don't require docstrings everywhere for now
   "D100", "D101", "D102", "D103", "D104", "D105",
   # Ignore shadowing
-  "A001", "A002",
+  "A001", "A002", "A003",
   # Allow print until we find the alternative to R's cli
   "T201"
 ]

--- a/src/outpack/config.py
+++ b/src/outpack/config.py
@@ -50,7 +50,7 @@ class ConfigCore:
 @dataclass
 class Location:
     name: str
-    type: str  # noqa: A003
+    type: str
     args: Optional[dict] = None
 
     def __init__(self, name, type, args=None):

--- a/src/outpack/helpers.py
+++ b/src/outpack/helpers.py
@@ -20,7 +20,6 @@ def _validate_files(files):
     return files
 
 
-
 def _plan_copy_files(root, id, files):
     meta = root.index.metadata(id)
     files = _validate_files(files)

--- a/src/outpack/helpers.py
+++ b/src/outpack/helpers.py
@@ -6,18 +6,24 @@ from outpack.root import as_root
 
 def copy_files(id, files, dest, *, root=None):
     root = as_root(root)
-    plan = plan_copy_files(root, id, files)
+    plan = _plan_copy_files(root, id, files)
     for here, there in plan.files.items():
         root.export_file(id, there, here, dest)
     return plan
 
 
-def plan_copy_files(root, id, files):
-    meta = root.index.metadata(id)
+def _validate_files(files):
     if isinstance(files, str):
         files = {files: files}
     if isinstance(files, list):
         files = {x: x for x in files}
+    return files
+
+
+
+def _plan_copy_files(root, id, files):
+    meta = root.index.metadata(id)
+    files = _validate_files(files)
     known = [p.path for p in meta.files]
     for k, v in files.items():
         # TODO: check absolute paths

--- a/src/outpack/helpers.py
+++ b/src/outpack/helpers.py
@@ -1,0 +1,37 @@
+from dataclasses import dataclass
+from typing import Dict
+
+from outpack.root import as_root
+
+
+def copy_files(id, files, dest, *, root=None):
+    root = as_root(root)
+    plan = plan_copy_files(root, id, files)
+    for here, there in plan.files.items():
+        root.export_file(id, there, here, dest)
+    return plan
+
+
+def plan_copy_files(root, id, files):
+    meta = root.index.metadata(id)
+    if isinstance(files, str):
+        files = {files: files}
+    if isinstance(files, list):
+        files = {x: x for x in files}
+    known = [p.path for p in meta.files]
+    for k, v in files.items():
+        # TODO: check absolute paths
+        if v.endswith("/") or k.endswith("/"):
+            msg = "Directories not yet supported for export"
+            raise Exception(msg)
+        if v not in known:
+            msg = f"Packet '{id}' does not contain the requested path '{v}'"
+            raise Exception(msg)
+    return Plan(id, meta.name, files)
+
+
+@dataclass
+class Plan:
+    id: str
+    name: str
+    files: Dict[str, str]

--- a/src/outpack/location_path.py
+++ b/src/outpack/location_path.py
@@ -10,7 +10,7 @@ class OutpackLocationPath:
     def __init__(self, path):
         self.__root = root_open(path, locate=False)
 
-    def list(self):  # noqa: A003
+    def list(self):
         return self.__root.index.location(LOCATION_LOCAL)
 
     def metadata(self, packet_ids):

--- a/src/outpack/metadata.py
+++ b/src/outpack/metadata.py
@@ -13,7 +13,7 @@ from outpack.tools import GitInfo
 class PacketFile:
     path: str
     size: float
-    hash: str  # noqa: A003
+    hash: str
 
     @staticmethod
     def from_file(directory, path, hash_algorithm):
@@ -36,6 +36,7 @@ class PacketDepends:
     packet: str
     query: str
     files: List[PacketDependsPath]
+
     @staticmethod
     def files_from_dict(files):
         return [{"here": h, "there": t} for h, t, in files.items()]
@@ -45,7 +46,7 @@ class PacketDepends:
 @dataclass
 class MetadataCore:
     schema_version: str
-    id: str  # noqa: A003
+    id: str
     name: str
     parameters: Dict[str, Union[bool, int, float, str]]
     time: Dict[str, float]
@@ -67,7 +68,7 @@ class MetadataCore:
 class PacketLocation:
     packet: str
     time: float
-    hash: str  # noqa: A003
+    hash: str
 
 
 def read_metadata_core(path):

--- a/src/outpack/metadata.py
+++ b/src/outpack/metadata.py
@@ -36,6 +36,9 @@ class PacketDepends:
     packet: str
     query: str
     files: List[PacketDependsPath]
+    @staticmethod
+    def files_from_dict(files):
+        return [{"here": h, "there": t} for h, t, in files.items()]
 
 
 @dataclass_json()

--- a/src/outpack/packet.py
+++ b/src/outpack/packet.py
@@ -4,11 +4,14 @@ from pathlib import Path
 
 from outpack.hash import hash_file, hash_parse, hash_string, hash_validate_file
 from outpack.ids import outpack_id, validate_outpack_id
-from outpack.metadata import MetadataCore, PacketFile, PacketLocation
+from outpack.metadata import MetadataCore, PacketDepends, PacketFile, PacketLocation
 from outpack.root import root_open
 from outpack.schema import outpack_schema_version, validate
+from outpack.search import search
+from outpack.search_query import as_query
 from outpack.tools import git_info
 from outpack.util import all_normal_files
+from outpack.helpers import copy_files
 
 
 # TODO: most of these fields should be private.
@@ -33,19 +36,19 @@ class Packet:
         self.metadata = None
         self.immutable = {}
 
-    def use_dependency(self, query, files, search_options):
+    def use_dependency(self, query, files, search_options=None):
         query = as_query(query)
         assert query.is_single
         id = search(query, options=search_options, root=self.root)
         if not id:
             msg = f"Failed to find packet for query {query}"
             raise Exception(msg)
-        result = copy_files(id, files, self.path,
-                            options=search_options, root=self.root)
-        for f, r in zip(files, result):
-            f.here = r
-            self.mark_file_immutable(f.here)
-        self.depends.append(PacketDepends(id, repr(query), files))
+
+        result = copy_files(id, files, self.path, root=self.root)
+        for f in result.files.keys():
+            self.mark_file_immutable(f)
+        d = PacketDepends(id, str(query), PacketDepends.files_from_dict(files))
+        self.depends.append(d)
         return result
 
     def mark_file_immutable(self, path):

--- a/src/outpack/packet.py
+++ b/src/outpack/packet.py
@@ -3,15 +3,20 @@ import time
 from pathlib import Path
 
 from outpack.hash import hash_file, hash_parse, hash_string, hash_validate_file
+from outpack.helpers import copy_files
 from outpack.ids import outpack_id, validate_outpack_id
-from outpack.metadata import MetadataCore, PacketDepends, PacketFile, PacketLocation
+from outpack.metadata import (
+    MetadataCore,
+    PacketDepends,
+    PacketFile,
+    PacketLocation,
+)
 from outpack.root import root_open
 from outpack.schema import outpack_schema_version, validate
 from outpack.search import search
 from outpack.search_query import as_query
 from outpack.tools import git_info
 from outpack.util import all_normal_files
-from outpack.helpers import copy_files
 
 
 # TODO: most of these fields should be private.
@@ -38,7 +43,7 @@ class Packet:
 
     def use_dependency(self, query, files, search_options=None):
         query = as_query(query)
-        assert query.is_single
+        # check query.is_single - can't be done until query expanded...
         id = search(query, options=search_options, root=self.root)
         if not id:
             msg = f"Failed to find packet for query {query}"

--- a/src/outpack/root.py
+++ b/src/outpack/root.py
@@ -9,6 +9,13 @@ from outpack.index import Index
 from outpack.util import find_file_descend
 
 
+def as_root(root):
+    if isinstance(root, OutpackRoot):
+        return root
+    else:
+        return OutpackRoot(root)
+
+
 class OutpackRoot:
     files = None
 

--- a/src/outpack/search.py
+++ b/src/outpack/search.py
@@ -1,4 +1,4 @@
-from outpack.root import OutpackRoot
+from outpack.root import as_root
 from outpack.search_options import SearchOptions
 from outpack.search_query import as_query
 
@@ -28,7 +28,7 @@ class QueryIndex:
 def search(expr, *, options=None, root=None):
     if options is None:
         options = SearchOptions()
-    root = OutpackRoot(root)
+    root = as_root(root)
     query = as_query(expr)
     env = QueryEnv(root, options)
     return query_eval(query.expr, env)

--- a/src/outpack/search.py
+++ b/src/outpack/search.py
@@ -1,6 +1,6 @@
 from outpack.root import OutpackRoot
 from outpack.search_options import SearchOptions
-from outpack.search_query import query_parse
+from outpack.search_query import as_query
 
 
 class QueryEnv:
@@ -29,7 +29,7 @@ def search(expr, *, options=None, root=None):
     if options is None:
         options = SearchOptions()
     root = OutpackRoot(root)
-    query = query_parse(expr)
+    query = as_query(expr)
     env = QueryEnv(root, options)
     return query_eval(query.expr, env)
 

--- a/src/outpack/search_query.py
+++ b/src/outpack/search_query.py
@@ -59,5 +59,5 @@ def query_parse_expr(expr):
 
 # This is not quite right, as id should map to single(<id>)
 def query_format(expr):
-    inner = expr.expr # from Query to QueryComponent
+    inner = expr.expr  # from Query to QueryComponent
     return inner.expr

--- a/src/outpack/search_query.py
+++ b/src/outpack/search_query.py
@@ -10,6 +10,9 @@ class Query:
         self.is_single = True
         self.parameters = []
 
+    def __str__(self):
+        return self.expr
+
 
 @dataclass
 class QueryComponent:
@@ -36,6 +39,12 @@ def query_parse(expr):
         expr = "latest()"
     expr = query_parse_expr(expr)
     return Query(expr)
+
+
+def as_query(expr):
+    if isinstance(expr, Query):
+        return expr
+    return query_parse(expr)
 
 
 def query_parse_expr(expr):

--- a/src/outpack/search_query.py
+++ b/src/outpack/search_query.py
@@ -11,7 +11,7 @@ class Query:
         self.parameters = []
 
     def __str__(self):
-        return self.expr
+        return query_format(self)
 
 
 @dataclass
@@ -55,3 +55,9 @@ def query_parse_expr(expr):
     else:
         msg = f"Unhandled query expression '{expr}'"
         raise Exception(msg)
+
+
+# This is not quite right, as id should map to single(<id>)
+def query_format(expr):
+    inner = expr.expr # from Query to QueryComponent
+    return inner.expr

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -1,0 +1,29 @@
+import helpers
+import pytest
+
+from outpack.helpers import _plan_copy_files, _validate_files
+
+
+def test_can_clean_file_input():
+    assert _validate_files("x") == {"x": "x"}
+    assert _validate_files(["x"]) == {"x": "x"}
+    assert _validate_files(["x", "y"]) == {"x": "x", "y": "y"}
+    assert _validate_files({"x": "x", "y": "y"}) == {"x": "x", "y": "y"}
+
+
+def test_can_create_plan(tmp_path):
+    root = helpers.create_temporary_root(tmp_path)
+    id = helpers.create_random_packet(root)
+    result = _plan_copy_files(root, id, {"here.txt": "data.txt"})
+    assert result.id == id
+    assert result.name == "data"
+    assert result.files == {"here.txt": "data.txt"}
+
+
+def test_can_error_if_plan_impossible(tmp_path):
+    root = helpers.create_temporary_root(tmp_path)
+    id = helpers.create_random_packet(root)
+    with pytest.raises(Exception, match="does not contain the requested path"):
+        _plan_copy_files(root, id, {"here.txt": "other.txt"})
+    with pytest.raises(Exception, match="Directories not yet supported"):
+        _plan_copy_files(root, id, {"here.txt": "data/"})

--- a/tests/test_packet.py
+++ b/tests/test_packet.py
@@ -260,3 +260,13 @@ def test_can_depend_on_a_packet(tmp_path):
     assert meta.depends[0].files == [
         PacketDependsPath("here.txt", "data.txt")
     ]
+
+
+def test_can_throw_if_dependency_not_satisfiable(tmp_path):
+    root = helpers.create_temporary_root(tmp_path)
+    src = tmp_path / "src"
+    src.mkdir()
+    p = Packet(root, src, "downstream")
+    id = "20230810-172859-6b0408e0"
+    with pytest.raises(Exception, match="Failed to find packet for query"):
+        p.use_dependency(id, {"here.txt": "data.txt"}, None)

--- a/tests/test_packet.py
+++ b/tests/test_packet.py
@@ -2,6 +2,7 @@ import helpers
 import pytest
 
 from outpack.init import outpack_init
+from outpack.metadata import PacketDependsPath
 from outpack.packet import Packet
 from outpack.root import root_open
 
@@ -239,3 +240,23 @@ def test_helper(tmp_path):
     assert isinstance(packet_id, str)
     meta = root_open(tmp_path, False).index.metadata(packet_id)
     assert meta.name == "data"
+
+
+def test_can_depend_on_a_packet(tmp_path):
+    root = helpers.create_temporary_root(tmp_path)
+    id = helpers.create_random_packet(root)
+    src = tmp_path / "src"
+    src.mkdir()
+    p = Packet(root, src, "downstream")
+    result = p.use_dependency(id, {"here.txt": "data.txt"}, None)
+    assert result.id == id
+    assert result.name == "data"
+    assert result.files == {"here.txt": "data.txt"}
+    p.end()
+    meta = root_open(tmp_path, False).index.metadata(p.id)
+    assert len(meta.depends) == 1
+    assert meta.depends[0].packet == id
+    assert meta.depends[0].query == id
+    assert meta.depends[0].files == [
+        PacketDependsPath("here.txt", "data.txt")
+    ]

--- a/tests/test_packet.py
+++ b/tests/test_packet.py
@@ -257,9 +257,7 @@ def test_can_depend_on_a_packet(tmp_path):
     assert len(meta.depends) == 1
     assert meta.depends[0].packet == id
     assert meta.depends[0].query == id
-    assert meta.depends[0].files == [
-        PacketDependsPath("here.txt", "data.txt")
-    ]
+    assert meta.depends[0].files == [PacketDependsPath("here.txt", "data.txt")]
 
 
 def test_can_throw_if_dependency_not_satisfiable(tmp_path):

--- a/tests/test_search_query.py
+++ b/tests/test_search_query.py
@@ -23,3 +23,10 @@ def test_can_parse_simple_id_query():
 def test_can_not_parse_interesting_query():
     with pytest.raises(Exception, match="Unhandled query expression"):
         query_parse("latest(parameter:x == this:y)")
+
+
+def test_can_convert_query_to_string():
+    x = "20230810-172859-6b0408e0"
+    assert str(query_parse(x)) == x
+    assert str(query_parse("latest()")) == "latest()"
+    assert str(query_parse("latest")) == "latest()"


### PR DESCRIPTION
This PR adds the low-level packet support for dependencies (i.e., the outpack bits). Some if this is a bit odd at the moment because we don't really have any form of query (we can't even do an unqualified `latest` as we now treat that more explicitly as `latest(name == "whatever")`). However, most of the bits are here otherwise:

* A helper to take care of the copying, with placeholders for future directory expansion
* A stub for query formatting, via `__str__()`
* Copy files in, add metadata, and mark immutable