### PR TITLE
mrc-4639: expand packet context

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -139,7 +139,7 @@ ignore = [
   # Don't require docstrings everywhere for now
   "D100", "D101", "D102", "D103", "D104", "D105",
   # Ignore shadowing
-  "A001", "A002",
+  "A001", "A002", "A003",
   # Allow print until we find the alternative to R's cli
   "T201"
 ]

--- a/src/orderly/core.py
+++ b/src/orderly/core.py
@@ -3,7 +3,7 @@ from typing import List
 
 from dataclasses_json import dataclass_json
 
-from orderly.current import get_active_packet
+from orderly.current import get_active_context
 from outpack import util
 
 
@@ -32,14 +32,14 @@ def resource(files):
     """
     files = util.relative_path_array(files, "resource")
     util.assert_file_exists(files)
-    p = get_active_packet()
-    src = p.packet.path if p else None
+    ctx = get_active_context()
+    src = ctx.path if ctx.is_active else None
     files_expanded = util.expand_dirs(files, workdir=src)
-    if p:
+    if ctx.is_active:
         # TODO: If strict mode, copy expanded files into the working dir
         for f in files_expanded:
-            p.packet.mark_file_immutable(f)
-        p.orderly.resources += files_expanded
+            ctx.packet.mark_file_immutable(f)
+        ctx.orderly.resources += files_expanded
     return files_expanded
 
 
@@ -74,7 +74,7 @@ def artefact(name, files):
 
     """
     files = util.relative_path_array(files, "artefact")
-    p = get_active_packet()
-    if p:
-        p.orderly.artefacts.append(Artefact(name, files))
+    ctx = get_active_context()
+    if ctx.is_active:
+        ctx.orderly.artefacts.append(Artefact(name, files))
     return files

--- a/src/orderly/current.py
+++ b/src/orderly/current.py
@@ -1,32 +1,93 @@
+import os
+from pathlib import Path
+from dataclasses import dataclass
+
+from outpack.packet import Packet
+from outpack.root import OutpackRoot, root_open
+
+
 class OrderlyCustomMetadata:
     def __init__(self):
         self.resources = []
         self.artefacts = []
 
 
-class RunningOrderlyPacket:
+@dataclass
+class OrderlyContext:
+    # Indicates if a packet is currently running
+    is_active: bool
+    # The active packet, if one is running
+    packet: Packet or None
+    # the path to the packet running directory. This is a pathlib Path object
+    path: Path
+    # the path to the packet source
+    path_src: Path
+    # The outpack root for the currently running packet
+    root: OutpackRoot
+    # Parameters used to run the packet
+    parameters: dict
+    # The name of the packet
+    name: str
+    # The id of the packet, only non-None if active
+    id: str or None
+    # Special orderly custom metadata
+    orderly: OrderlyCustomMetadata
+
+    @staticmethod
+    def from_packet(packet, path_src):
+        return OrderlyContext(
+            is_active=True,
+            packet=packet,
+            path=packet.path,
+            path_src=Path(path_src),
+            root=packet.root,
+            parameters=packet.parameters,
+            name=packet.name,
+            id=packet.id,
+            orderly=OrderlyCustomMetadata())
+
+    @staticmethod
+    def interactive():
+        path = Path(os.getcwd())
+        return OrderlyContext(
+            is_active=False,
+            packet=None,
+            path=path,
+            path_src=path,
+            root=root_open(detect_orderly_interactive_path(path), False),
+            parameters={},
+            name=path.name,
+            id=None,
+            orderly=OrderlyCustomMetadata())
+
+
+class ActiveOrderlyContext:
+    _context = None
+    _our_context = None
+
     def __init__(self, packet, path_src):
-        self.packet = packet
-        self.path_src = path_src
-        self.orderly = OrderlyCustomMetadata()
-
-
-class ActiveOrderlyPacket:
-    _packet = None
-
-    def __init__(self, packet, path_src):
-        self._our_packet = RunningOrderlyPacket(packet, path_src)
+        self._our_context = OrderlyContext.from_packet(packet, path_src)
 
     def __enter__(self):
-        ActiveOrderlyPacket._packet = self._our_packet
-        return self._our_packet.orderly
+        ActiveOrderlyContext._context = self._our_context
+        return self._our_context.orderly
 
     def __exit__(self, exc_type, exc_value, exc_tb):
-        ActiveOrderlyPacket._packet = None
+        ActiveOrderlyContext._context = None
 
     def current():
-        return ActiveOrderlyPacket._packet
+        return ActiveOrderlyContext._context
 
 
-def get_active_packet():
-    return ActiveOrderlyPacket.current()
+def get_active_context():
+    return ActiveOrderlyContext.current() or OrderlyContext.interactive()
+
+
+def detect_orderly_interactive_path(path):
+    path = Path(path)
+    root = path.parent.parent
+    ok = root.joinpath("src").is_dir() and root.joinpath(".outpack").exists()
+    if not ok:
+        msg = f"Failed to detect orderly path at {path}"
+        raise Exception(msg)
+    return root

--- a/src/orderly/current.py
+++ b/src/orderly/current.py
@@ -1,6 +1,6 @@
 import os
-from pathlib import Path
 from dataclasses import dataclass
+from pathlib import Path
 
 from outpack.packet import Packet
 from outpack.root import OutpackRoot, root_open
@@ -44,7 +44,8 @@ class OrderlyContext:
             parameters=packet.parameters,
             name=packet.name,
             id=packet.id,
-            orderly=OrderlyCustomMetadata())
+            orderly=OrderlyCustomMetadata(),
+        )
 
     @staticmethod
     def interactive():
@@ -58,7 +59,8 @@ class OrderlyContext:
             parameters={},
             name=path.name,
             id=None,
-            orderly=OrderlyCustomMetadata())
+            orderly=OrderlyCustomMetadata(),
+        )
 
 
 class ActiveOrderlyContext:

--- a/src/orderly/current.py
+++ b/src/orderly/current.py
@@ -54,7 +54,7 @@ class OrderlyContext:
             packet=None,
             path=path,
             path_src=path,
-            root=root_open(detect_orderly_interactive_path(path), False),
+            root=detect_orderly_interactive_root(path),
             parameters={},
             name=path.name,
             id=None,
@@ -83,11 +83,11 @@ def get_active_context():
     return ActiveOrderlyContext.current() or OrderlyContext.interactive()
 
 
-def detect_orderly_interactive_path(path):
+def detect_orderly_interactive_root(path):
     path = Path(path)
     root = path.parent.parent
     ok = root.joinpath("src").is_dir() and root.joinpath(".outpack").exists()
     if not ok:
         msg = f"Failed to detect orderly path at {path}"
         raise Exception(msg)
-    return root
+    return root_open(root, False)

--- a/src/orderly/run.py
+++ b/src/orderly/run.py
@@ -1,6 +1,6 @@
 import shutil
 
-from orderly.current import ActiveOrderlyPacket
+from orderly.current import ActiveOrderlyContext
 from outpack.ids import outpack_id
 from outpack.packet import Packet
 from outpack.root import root_open
@@ -20,7 +20,7 @@ def orderly_run(name, *, root=None, locate=True):
 
     packet = Packet(root, path_dest, name, id=packet_id, locate=False)
     try:
-        with ActiveOrderlyPacket(packet, path_src) as orderly:
+        with ActiveOrderlyContext(packet, path_src) as orderly:
             packet.mark_file_immutable("orderly.py")
             run_script(path_dest, "orderly.py")
     except Exception as error:

--- a/src/outpack/config.py
+++ b/src/outpack/config.py
@@ -50,7 +50,7 @@ class ConfigCore:
 @dataclass
 class Location:
     name: str
-    type: str  # noqa: A003
+    type: str
     args: Optional[dict] = None
 
     def __init__(self, name, type, args=None):

--- a/src/outpack/location_path.py
+++ b/src/outpack/location_path.py
@@ -10,7 +10,7 @@ class OutpackLocationPath:
     def __init__(self, path):
         self.__root = root_open(path, locate=False)
 
-    def list(self):  # noqa: A003
+    def list(self):
         return self.__root.index.location(LOCATION_LOCAL)
 
     def metadata(self, packet_ids):

--- a/src/outpack/metadata.py
+++ b/src/outpack/metadata.py
@@ -13,7 +13,7 @@ from outpack.tools import GitInfo
 class PacketFile:
     path: str
     size: float
-    hash: str  # noqa: A003
+    hash: str
 
     @staticmethod
     def from_file(directory, path, hash_algorithm):
@@ -42,7 +42,7 @@ class PacketDepends:
 @dataclass
 class MetadataCore:
     schema_version: str
-    id: str  # noqa: A003
+    id: str
     name: str
     parameters: Dict[str, Union[bool, int, float, str]]
     time: Dict[str, float]
@@ -64,7 +64,7 @@ class MetadataCore:
 class PacketLocation:
     packet: str
     time: float
-    hash: str  # noqa: A003
+    hash: str
 
 
 def read_metadata_core(path):

--- a/tests/orderly/test_current.py
+++ b/tests/orderly/test_current.py
@@ -1,10 +1,6 @@
-import pytest
-
-from outpack.util import transient_working_directory
-from outpack.root import OutpackRoot, root_open
-from orderly.current import detect_orderly_interactive_root
-
 import helpers
+import pytest
+from orderly.current import detect_orderly_interactive_root
 
 
 def test_can_open_root_interactively(tmp_path):
@@ -18,7 +14,7 @@ def test_can_open_root_interactively(tmp_path):
 
 
 def test_can_error_if_interactive_directory_incorrect(tmp_path):
-    root = helpers.create_temporary_root(tmp_path)
+    helpers.create_temporary_root(tmp_path)
     src = tmp_path / "src" / "x"
     src.mkdir(parents=True)
     child = src / "a"

--- a/tests/orderly/test_current.py
+++ b/tests/orderly/test_current.py
@@ -1,0 +1,29 @@
+import pytest
+
+from outpack.util import transient_working_directory
+from outpack.root import OutpackRoot, root_open
+from orderly.current import detect_orderly_interactive_root
+
+import helpers
+
+
+def test_can_open_root_interactively(tmp_path):
+    root = helpers.create_temporary_root(tmp_path)
+    src = tmp_path / "src" / "x"
+    src.mkdir(parents=True)
+    res = detect_orderly_interactive_root(src)
+    assert isinstance(res, type(root))
+    assert res.path == root.path
+    assert res.config == root.config
+
+
+def test_can_error_if_interactive_directory_incorrect(tmp_path):
+    root = helpers.create_temporary_root(tmp_path)
+    src = tmp_path / "src" / "x"
+    src.mkdir(parents=True)
+    child = src / "a"
+    child.mkdir()
+    with pytest.raises(Exception, match="Failed to detect orderly path at"):
+        detect_orderly_interactive_root(src.parent)
+    with pytest.raises(Exception, match="Failed to detect orderly path at"):
+        detect_orderly_interactive_root(child)

--- a/tests/orderly/test_run_metadata.py
+++ b/tests/orderly/test_run_metadata.py
@@ -1,16 +1,14 @@
+import helpers
 import orderly
 import pytest
 from orderly.current import ActiveOrderlyContext
 
-from outpack.init import outpack_init
 from outpack.packet import Packet
 from outpack.util import transient_working_directory
 
-import helpers
-
 
 def test_resource_requires_that_files_exist_with_no_packet(tmp_path):
-    root = helpers.create_temporary_root(tmp_path)
+    helpers.create_temporary_root(tmp_path)
     src = tmp_path / "src" / "x"
     src.mkdir(parents=True)
     with transient_working_directory(src):
@@ -33,8 +31,8 @@ def test_resource_requires_relative_paths(tmp_path):
         orderly.resource(str(tmp_path / "a"))
 
 
-def test_resource_expands_lists_with_no_packet(tmp_path): 
-    root = helpers.create_temporary_root(tmp_path)
+def test_resource_expands_lists_with_no_packet(tmp_path):
+    helpers.create_temporary_root(tmp_path)
     src = tmp_path / "src" / "x"
     src.mkdir(parents=True)
     sub = src / "a"
@@ -64,8 +62,8 @@ def test_resource_requires_file_exists_with_packet(tmp_path):
     assert active.resources == res
 
 
-def test_artefact_is_allowed_without_packet(tmp_path): 
-    root = helpers.create_temporary_root(tmp_path)
+def test_artefact_is_allowed_without_packet(tmp_path):
+    helpers.create_temporary_root(tmp_path)
     src = tmp_path / "src" / "x"
     src.mkdir(parents=True)
     with transient_working_directory(src):

--- a/tests/orderly/test_run_metadata.py
+++ b/tests/orderly/test_run_metadata.py
@@ -1,19 +1,24 @@
 import orderly
 import pytest
-from orderly.current import ActiveOrderlyPacket
+from orderly.current import ActiveOrderlyContext
 
 from outpack.init import outpack_init
 from outpack.packet import Packet
 from outpack.util import transient_working_directory
 
+import helpers
+
 
 def test_resource_requires_that_files_exist_with_no_packet(tmp_path):
-    with transient_working_directory(tmp_path):
+    root = helpers.create_temporary_root(tmp_path)
+    src = tmp_path / "src" / "x"
+    src.mkdir(parents=True)
+    with transient_working_directory(src):
         with pytest.raises(Exception, match="File does not exist:"):
             orderly.resource("a")
-    with open(tmp_path / "a", "w"):
+    with open(src / "a", "w"):
         pass
-    with transient_working_directory(tmp_path):
+    with transient_working_directory(src):
         res = orderly.resource("a")
     assert res == ["a"]
 
@@ -28,37 +33,41 @@ def test_resource_requires_relative_paths(tmp_path):
         orderly.resource(str(tmp_path / "a"))
 
 
-def test_resource_expands_lists_with_no_packet(tmp_path):
-    sub = tmp_path / "a"
+def test_resource_expands_lists_with_no_packet(tmp_path): 
+    root = helpers.create_temporary_root(tmp_path)
+    src = tmp_path / "src" / "x"
+    src.mkdir(parents=True)
+    sub = src / "a"
     sub.mkdir()
     with open(sub / "x", "w"):
         pass
     with open(sub / "y", "w"):
         pass
 
-    with transient_working_directory(tmp_path):
+    with transient_working_directory(src):
         res = orderly.resource("a")
     assert sorted(res) == ["a/x", "a/y"]
 
 
 def test_resource_requires_file_exists_with_packet(tmp_path):
-    root = tmp_path / "root"
-    outpack_init(root)
-    src = tmp_path / "src"
-    src.mkdir()
+    root = helpers.create_temporary_root(tmp_path)
+    src = tmp_path / "src" / "x"
+    src.mkdir(parents=True)
     with open(src / "a", "w"):
         pass
 
     p = Packet(root, src, "tmp")
-    # TODO: ActiveOrderlyPacket should do this directory shift I think
-    with ActiveOrderlyPacket(p, src) as active:
+    with ActiveOrderlyContext(p, src) as active:
         with transient_working_directory(src):
             res = orderly.resource(["a"])
 
     assert active.resources == res
 
 
-def test_artefact_is_allowed_without_packet(tmp_path):
-    with transient_working_directory(tmp_path):
+def test_artefact_is_allowed_without_packet(tmp_path): 
+    root = helpers.create_temporary_root(tmp_path)
+    src = tmp_path / "src" / "x"
+    src.mkdir(parents=True)
+    with transient_working_directory(src):
         res = orderly.artefact("a", "b")
     assert res == ["b"]


### PR DESCRIPTION
This PR expands the idea of a running packet to better match the orderly context - not sure why I didn't do it this way at first, really. No change to behaviour of most functions, but this will make building support for dependencies, shared resources etc much easier.

Note that parameters here will be hard to support interactively, I've left them off for now