### PR TITLE
Fix rounding bug in id generation

### DIFF
--- a/src/outpack/ids.py
+++ b/src/outpack/ids.py
@@ -15,10 +15,7 @@ def fractional_to_bytes(x):
 def outpack_id():
     t = time.time()
     rand = secrets.token_hex(2)
-    id = f"{iso_time_str(t)}-{fractional_to_bytes(t)}{rand}"
-    if len(id) != 24:
-        breakpoint()
-    return id
+    return f"{iso_time_str(t)}-{fractional_to_bytes(t)}{rand}"
 
 
 def is_outpack_id(x: str):

--- a/src/outpack/ids.py
+++ b/src/outpack/ids.py
@@ -1,3 +1,4 @@
+import math
 import re
 import secrets
 import time
@@ -8,13 +9,16 @@ RE_ID = re.compile("^[0-9]{8}-[0-9]{6}-[0-9a-f]{8}$")
 
 
 def fractional_to_bytes(x):
-    return f"{round((x % 1) * pow(256, 2)):04x}"
+    return f"{math.floor((x % 1) * pow(256, 2)):04x}"
 
 
 def outpack_id():
     t = time.time()
     rand = secrets.token_hex(2)
-    return f"{iso_time_str(t)}-{fractional_to_bytes(t)}{rand}"
+    id = f"{iso_time_str(t)}-{fractional_to_bytes(t)}{rand}"
+    if len(id) != 24:
+        breakpoint()
+    return id
 
 
 def is_outpack_id(x: str):

--- a/tests/test_ids.py
+++ b/tests/test_ids.py
@@ -9,11 +9,12 @@ from outpack.ids import (
 
 
 def test_fractional_to_bytes():
-    assert fractional_to_bytes(1691686967.895351) == "e536"
+    assert fractional_to_bytes(1691686967.895351) == "e535"
     assert fractional_to_bytes(100) == "0000"
-    assert fractional_to_bytes(100.0001) == "0007"
-    assert fractional_to_bytes(100.001) == "0042"
-    assert fractional_to_bytes(100.05) == "0ccd"
+    assert fractional_to_bytes(100.0001) == "0006"
+    assert fractional_to_bytes(100.001) == "0041"
+    assert fractional_to_bytes(100.05) == "0ccc"
+    assert fractional_to_bytes(1696872486.999993) == "ffff"
 
 
 def test_outpack_id_creation():


### PR DESCRIPTION
I saw this fail on a build, and tracked it down to a 1 / 131072 (I think) chance of failure. Switching to floor rather than round fixes it.