### PR TITLE
Mrc 4641

### DIFF
--- a/src/orderly/__init__.py
+++ b/src/orderly/__init__.py
@@ -1,3 +1,3 @@
-from orderly.core import artefact, resource
+from orderly.core import artefact, description, resource
 
-__all__ = ["artefact", "resource"]
+__all__ = ["artefact", "description", "resource"]

--- a/src/orderly/current.py
+++ b/src/orderly/current.py
@@ -10,6 +10,7 @@ class OrderlyCustomMetadata:
     def __init__(self):
         self.resources = []
         self.artefacts = []
+        self.description = None
 
 
 @dataclass

--- a/src/orderly/run.py
+++ b/src/orderly/run.py
@@ -1,5 +1,6 @@
 import shutil
 
+from orderly.core import Description
 from orderly.current import ActiveOrderlyContext
 from outpack.ids import outpack_id
 from outpack.packet import Packet
@@ -87,7 +88,11 @@ def _custom_metadata(orderly):
     for p in orderly.resources:
         role.append({"path": p, "role": "resource"})
 
-    return {"role": role, "artefacts": orderly.artefacts}
+    return {
+        "role": role,
+        "artefacts": orderly.artefacts,
+        "description": orderly.description or Description.empty(),
+    }
 
 
 def _orderly_cleanup_failure(packet):

--- a/tests/helpers/__init__.py
+++ b/tests/helpers/__init__.py
@@ -1,5 +1,6 @@
 import os
 import random
+import shutil
 from tempfile import TemporaryDirectory
 
 from outpack.init import outpack_init
@@ -21,3 +22,13 @@ def create_random_packet(root, name="data", parameters=None, packet_id=None):
 def create_temporary_root(path, **kwargs):
     outpack_init(path, **kwargs)
     return root_open(path, False)
+
+
+def create_orderly_root(path, examples):
+    outpack_init(path)
+    if isinstance(examples, str):
+        examples = [examples]
+    for ex in examples:
+        path_src = path / "src" / ex
+        path_src.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copytree(f"tests/orderly/examples/{ex}", path_src)

--- a/tests/orderly/examples/description/orderly.py
+++ b/tests/orderly/examples/description/orderly.py
@@ -1,0 +1,3 @@
+import orderly
+
+orderly.description(display="Some report")

--- a/tests/orderly/test_run.py
+++ b/tests/orderly/test_run.py
@@ -1,5 +1,6 @@
 import shutil
 
+import helpers
 import pytest
 from orderly.run import _validate_src_directory, orderly_run
 
@@ -36,6 +37,7 @@ def test_can_run_simple_example(tmp_path):
         "orderly": {
             "role": [{"path": "orderly.py", "role": "orderly"}],
             "artefacts": [],
+            "description": {"display": None, "long": None, "custom": None},
         }
     }
     assert meta.custom == custom
@@ -113,6 +115,7 @@ def test_can_run_example_with_resource(tmp_path):
                 {"path": "numbers.txt", "role": "resource"},
             ],
             "artefacts": [],
+            "description": {"display": None, "long": None, "custom": None},
         }
     }
     assert meta.custom == custom
@@ -144,6 +147,7 @@ def test_can_run_example_with_artefact(tmp_path):
         "orderly": {
             "role": [{"path": "orderly.py", "role": "orderly"}],
             "artefacts": [{"name": "Random numbers", "files": ["result.txt"]}],
+            "description": {"display": None, "long": None, "custom": None},
         }
     }
     assert meta.custom == custom
@@ -176,3 +180,14 @@ def test_can_error_if_artefacts_not_produced(tmp_path):
         match="Script did not produce the expected artefacts: 'a', 'b', 'c'",
     ):
         orderly_run("resource", root=path)
+
+
+def test_can_run_with_description(tmp_path):
+    helpers.create_orderly_root(tmp_path, ["description"])
+    id = orderly_run("description", root=tmp_path)
+    meta = root_open(tmp_path, False).index.metadata(id)
+    assert meta.custom["orderly"]["description"] == {
+        "display": "Some report",
+        "long": None,
+        "custom": None,
+    }

--- a/tests/orderly/test_run_metadata.py
+++ b/tests/orderly/test_run_metadata.py
@@ -99,7 +99,7 @@ def test_cant_add_description_twice(tmp_path):
 
 
 def test_can_run_description_without_packet_with_no_effect(tmp_path):
-    root = helpers.create_temporary_root(tmp_path)
+    helpers.create_temporary_root(tmp_path)
     src = tmp_path / "src" / "x"
     src.mkdir(parents=True)
     with transient_working_directory(src):

--- a/tests/orderly/test_run_metadata.py
+++ b/tests/orderly/test_run_metadata.py
@@ -69,3 +69,43 @@ def test_artefact_is_allowed_without_packet(tmp_path):
     with transient_working_directory(src):
         res = orderly.artefact("a", "b")
     assert res == ["b"]
+
+
+def test_can_add_description(tmp_path):
+    root = helpers.create_temporary_root(tmp_path)
+    src = tmp_path / "src"
+    src.mkdir()
+    p = Packet(root, src, "tmp")
+    with ActiveOrderlyContext(p, src) as active:
+        orderly.description(
+            long="long description",
+            display="display description",
+            custom={"a": 1, "b": "foo"},
+        )
+    assert active.description.long == "long description"
+    assert active.description.display == "display description"
+    assert active.description.custom == {"a": 1, "b": "foo"}
+
+
+def test_cant_add_description_twice(tmp_path):
+    root = helpers.create_temporary_root(tmp_path)
+    src = tmp_path / "src" / "x"
+    src.mkdir(parents=True)
+    p = Packet(root, src, "tmp")
+    with ActiveOrderlyContext(p, src):
+        orderly.description(long="long description")
+        with pytest.raises(Exception, match="Only one call to 'description'"):
+            orderly.description(display="display description")
+
+
+def test_can_run_description_without_packet_with_no_effect(tmp_path):
+    root = helpers.create_temporary_root(tmp_path)
+    src = tmp_path / "src" / "x"
+    src.mkdir(parents=True)
+    with transient_working_directory(src):
+        res = orderly.description(
+            long="long description",
+            display="display description",
+            custom={"a": 1, "b": "foo"},
+        )
+    assert res is None


### PR DESCRIPTION
~Merge after #24, contains those commits~

This PR adds support for adding human-readable descriptions to a packet (description, long name, custom metadata). Follows very closely the approach in the R version, though one thing that does occur to me is that this might be done better by a comment. Imagine that the top of the file contains a triple-quote header like

```
"""
Display name.

The long description could go here.

foo: bar
"""
```

We can access that by getting the `__doc__` element from the file corresponding to `orderly.py`, which we can access reasonably easily. Not sure if this is less weird or more weird, but this is similar to what docopt does (though there it works by having the user explicitly pass `__doc__`). Thoughts very welcome.