### PR TITLE
Basic orderly-style dependencies

### DIFF
--- a/src/orderly/__init__.py
+++ b/src/orderly/__init__.py
@@ -1,3 +1,3 @@
-from orderly.core import artefact, description, resource
+from orderly.core import artefact, description, dependency, resource
 
-__all__ = ["artefact", "description", "resource"]
+__all__ = ["artefact", "dependency", "description", "resource"]

--- a/src/orderly/__init__.py
+++ b/src/orderly/__init__.py
@@ -1,3 +1,3 @@
-from orderly.core import artefact, description, dependency, resource
+from orderly.core import artefact, dependency, description, resource
 
 __all__ = ["artefact", "dependency", "description", "resource"]

--- a/src/orderly/core.py
+++ b/src/orderly/core.py
@@ -157,8 +157,8 @@ def dependency(name, query, files):
     else:
         # TODO: get options from the interactive search options, once
         # it does anything.
-        id = search(query, root=root)
-        result = copy_files(id, files, self.path, root=root)
+        id = search(query, root=ctx.root)
+        result = copy_files(id, files, ctx.path, root=ctx.root)
     # TODO: print about this, once we decide what that looks like generally
     return result
 

--- a/src/orderly/core.py
+++ b/src/orderly/core.py
@@ -4,6 +4,7 @@ from typing import Dict, List
 from dataclasses_json import dataclass_json
 
 from orderly.current import get_active_context
+from outpack.helpers import copy_files
 from outpack import util
 
 
@@ -115,6 +116,37 @@ def description(*, display=None, long=None, custom=None):
     if ctx.is_active:
         _prevent_multiple_calls(ctx.orderly.description, "description")
         ctx.orderly.description = Description(display, long, custom)
+
+
+def dependency(name, query, files):
+    """Declare a dependency on another packet.
+
+    Parameters
+    ----------
+    name: str | None
+      The name of the packet to depend on, or None
+
+    query: str
+      A search query for packets
+
+    files: str | [str] | dict[str, str]
+      Files to use from the dependent packet
+    """
+
+    # ctx <- orderly_context(rlang::caller_env())
+    # subquery <- NULL
+    # query <- orderly_query(query, name = name, subquery = subquery)
+    # search_options <- as_orderly_search_options(ctx$search_options)
+    p = get_active_packet()
+    if p:
+        # TODO: search options here from need to come through from
+        # orderly_run via the context.
+        result = p.packet.use_dependency(query, files)
+    else:
+        id = search(query, options=search_options, root=root)
+        result = copy_files(id, files, self.path, root=root)
+    # TODO: print about this
+    return result
 
 
 def _prevent_multiple_calls(obj, what):

--- a/src/orderly/core.py
+++ b/src/orderly/core.py
@@ -4,10 +4,10 @@ from typing import Dict, List
 from dataclasses_json import dataclass_json
 
 from orderly.current import get_active_context
-from outpack.helpers import copy_files
-from outpack.search_query import as_query
-from outpack.search import search
 from outpack import util
+from outpack.helpers import copy_files
+from outpack.search import search
+from outpack.search_query import as_query
 
 
 @dataclass_json()

--- a/tests/helpers/__init__.py
+++ b/tests/helpers/__init__.py
@@ -1,6 +1,7 @@
 import os
 import random
 import shutil
+from pathlib import Path
 from tempfile import TemporaryDirectory
 
 from outpack.init import outpack_init
@@ -32,3 +33,12 @@ def create_orderly_root(path, examples):
         path_src = path / "src" / ex
         path_src.parent.mkdir(parents=True, exist_ok=True)
         shutil.copytree(f"tests/orderly/examples/{ex}", path_src)
+
+
+def copy_examples(names, root):
+    if isinstance(names, str):
+        names = [names]
+    for nm in names:
+        path_src = root.path / "src" / nm
+        path_src.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copytree(Path("tests/orderly/examples") / nm, path_src)

--- a/tests/orderly/examples/depends/orderly.py
+++ b/tests/orderly/examples/depends/orderly.py
@@ -1,0 +1,10 @@
+import orderly
+
+orderly.dependency(None, "latest", {"input.txt": "result.txt"})
+orderly.artefact("Summary", "summary.txt")
+
+with open("input.txt") as f:
+    d = [float(x.strip()) for x in f.readlines()]
+total = sum(d)
+with open("summary.txt", "w") as f:
+    f.write(f"{total}\n")

--- a/tests/orderly/test_run.py
+++ b/tests/orderly/test_run.py
@@ -207,3 +207,4 @@ def test_can_run_simple_dependency(tmp_path):
     assert len(meta.depends[0].files)
     assert meta.depends[0].files[0].here == "input.txt"
     assert meta.depends[0].files[0].there == "result.txt"
+    

--- a/tests/orderly/test_run.py
+++ b/tests/orderly/test_run.py
@@ -8,6 +8,8 @@ from outpack.init import outpack_init
 from outpack.metadata import read_metadata_core
 from outpack.root import root_open
 
+import helpers
+
 
 ## We're going to need a small test helper module here at some point,
 ## unfortunately pytest makes that totally unobvious how we do it, but
@@ -191,3 +193,17 @@ def test_can_run_with_description(tmp_path):
         "long": None,
         "custom": None,
     }
+
+
+def test_can_run_simple_dependency(tmp_path):
+    root = helpers.create_temporary_root(tmp_path)
+    helpers.copy_examples(["data", "depends"], root)
+    id1 = orderly_run("data", root=tmp_path)
+    id2 = orderly_run("depends", root=tmp_path)
+    meta = root.index.metadata(id2)
+    assert len(meta.depends) == 1
+    assert meta.depends[0].packet == id1
+    assert meta.depends[0].query == "latest()"
+    assert len(meta.depends[0].files)
+    assert meta.depends[0].files[0].here == "input.txt"
+    assert meta.depends[0].files[0].there == "result.txt"

--- a/tests/orderly/test_run.py
+++ b/tests/orderly/test_run.py
@@ -8,8 +8,6 @@ from outpack.init import outpack_init
 from outpack.metadata import read_metadata_core
 from outpack.root import root_open
 
-import helpers
-
 
 ## We're going to need a small test helper module here at some point,
 ## unfortunately pytest makes that totally unobvious how we do it, but
@@ -207,4 +205,3 @@ def test_can_run_simple_dependency(tmp_path):
     assert len(meta.depends[0].files)
     assert meta.depends[0].files[0].here == "input.txt"
     assert meta.depends[0].files[0].there == "result.txt"
-    

--- a/tests/orderly/test_run_metadata.py
+++ b/tests/orderly/test_run_metadata.py
@@ -3,7 +3,6 @@ import sys
 import helpers
 import orderly
 import pytest
-
 from orderly.current import ActiveOrderlyContext
 from orderly.run import orderly_run
 
@@ -124,7 +123,7 @@ def test_can_use_dependency(tmp_path):
     src = tmp_path / "draft" / "depends" / "some-id"
     src.mkdir(parents=True)
     p = Packet(root, src, "tmp")
-    with ActiveOrderlyContext(p, src) as active:
+    with ActiveOrderlyContext(p, src):
         with transient_working_directory(src):
             files = {"input.txt": "result.txt"}
             res = orderly.dependency(None, "latest", files)
@@ -137,13 +136,13 @@ def test_can_use_dependency(tmp_path):
 def test_dependency_must_have_empty_name(tmp_path):
     root = helpers.create_temporary_root(tmp_path)
     helpers.copy_examples(["data", "depends"], root)
-    id1 = orderly_run("data", root=tmp_path)
+    orderly_run("data", root=tmp_path)
     src = tmp_path / "src" / "depends"
     p = Packet(root, src, "tmp")
-    with ActiveOrderlyContext(p, src) as active:
+    with ActiveOrderlyContext(p, src):
         with transient_working_directory(src):
             with pytest.raises(Exception, match="'name' must be None"):
-                res = orderly.dependency("data", "latest", {})
+                orderly.dependency("data", "latest", {})
 
 
 def test_can_use_dependency_without_packet(tmp_path):


### PR DESCRIPTION
This PR implements dependencies from orderly (on top of the basic outpack dependencies in #23). It's naturally very limited because we don't have proper searching done yet, but I've flagged some of the big missing bits.

It also exposes that we need to start thinking about a sensible API for this package, something to sit down and plot together in November I think?