### PR TITLE
mrc-4577: Run orderly report with parameters

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,15 +39,15 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install hatch
-      - name: Lint
-        run: |
-          hatch run lint:all
       - name: Test
         env:
           VAULT_TOKEN: ${{ secrets.VAULT_TOKEN }}
           YOUTRACK_TOKEN: ${{ secrets.YOUTRACK_TOKEN }}
         run: |
           hatch run cov-ci
+      - name: Lint
+        run: |
+          hatch run lint:all
       - name: Upload to Codecov
         uses: codecov/codecov-action@v3
         with:

--- a/src/orderly/__init__.py
+++ b/src/orderly/__init__.py
@@ -1,3 +1,3 @@
-from orderly.core import artefact, dependency, description, resource
+from orderly.core import artefact, dependency, description, parameters, resource
 
-__all__ = ["artefact", "dependency", "description", "resource"]
+__all__ = ["artefact", "dependency", "description", "parameters", "resource"]

--- a/src/orderly/core.py
+++ b/src/orderly/core.py
@@ -39,7 +39,7 @@ def parameters(**kwargs):  # noqa: ARG001
 
     Returns
     -------
-    Nothing, this function hs no effect at all!
+    Nothing, this function has no effect at all!
     """
     pass
 

--- a/src/orderly/core.py
+++ b/src/orderly/core.py
@@ -28,6 +28,14 @@ class Description:
         return Description(None, None, None)
 
 
+def parameters(**kwargs):
+    ctx = get_active_context()
+    if ctx.is_active:
+        pass
+    else:
+        _check_parameters_interactive(ctx.envir, kwargs)
+
+
 def resource(files):
     """Declare that a file, or group of files, are an orderly resource.
 
@@ -165,3 +173,7 @@ def _prevent_multiple_calls(obj, what):
     if obj:
         msg = f"Only one call to '{what}' is allowed"
         raise Exception(msg)
+
+
+def _check_parameters_interactive(envir, defaults):
+    pass

--- a/src/orderly/core.py
+++ b/src/orderly/core.py
@@ -28,12 +28,20 @@ class Description:
         return Description(None, None, None)
 
 
-def parameters(**kwargs):
-    ctx = get_active_context()
-    if ctx.is_active:
-        pass
-    else:
-        _check_parameters_interactive(ctx.envir, kwargs)
+def parameters(**kwargs):  # noqa: ARG001
+    """Declare parameters used in a report.
+
+    Parameters
+    ----------
+    kwargs :
+      Keyword mappings of parameter names to default values (or to None
+      if no default is given)
+
+    Returns
+    -------
+    Nothing, this function hs no effect at all!
+    """
+    pass
 
 
 def resource(files):
@@ -173,7 +181,3 @@ def _prevent_multiple_calls(obj, what):
     if obj:
         msg = f"Only one call to '{what}' is allowed"
         raise Exception(msg)
-
-
-def _check_parameters_interactive(envir, defaults):
-    pass

--- a/src/orderly/current.py
+++ b/src/orderly/current.py
@@ -34,9 +34,6 @@ class OrderlyContext:
     id: Optional[str]
     # Special orderly custom metadata
     orderly: OrderlyCustomMetadata
-    # Execution environment; currently this is globals() but we'll
-    # tidy this up later
-    envir: dict
 
     @staticmethod
     def from_packet(packet, path_src):
@@ -50,7 +47,6 @@ class OrderlyContext:
             name=packet.name,
             id=packet.id,
             orderly=OrderlyCustomMetadata(),
-            envir=globals(),
         )
 
     @staticmethod
@@ -66,7 +62,6 @@ class OrderlyContext:
             name=path.name,
             id=None,
             orderly=OrderlyCustomMetadata(),
-            envir=globals(),
         )
 
 

--- a/src/orderly/current.py
+++ b/src/orderly/current.py
@@ -34,6 +34,9 @@ class OrderlyContext:
     id: Optional[str]
     # Special orderly custom metadata
     orderly: OrderlyCustomMetadata
+    # Execution environment; currently this is globals() but we'll
+    # tidy this up later
+    envir: dict
 
     @staticmethod
     def from_packet(packet, path_src):
@@ -47,6 +50,7 @@ class OrderlyContext:
             name=packet.name,
             id=packet.id,
             orderly=OrderlyCustomMetadata(),
+            envir=globals(),
         )
 
     @staticmethod
@@ -62,6 +66,7 @@ class OrderlyContext:
             name=path.name,
             id=None,
             orderly=OrderlyCustomMetadata(),
+            envir=globals(),
         )
 
 

--- a/src/orderly/read.py
+++ b/src/orderly/read.py
@@ -1,0 +1,65 @@
+import ast
+
+
+def orderly_read(path):
+    with open(path) as f:
+        src = ast.parse(f.read())
+    return _read_py(src)
+
+
+# In the R version of this function we do a more involved read, trying
+# to handle "static" versions of all of the orderly core
+# functions. However,we then never actually used that for anything, so
+# to avoid overcomplication we'll do the least possible here which is
+# just to read the parameters from the file, verify that it is only
+# called once, and that is called at the top-level.
+#
+# The return value does nod at future extension though.
+def _read_py(src):
+    ret = {"parameters": []}
+    for expr in src.body:
+        dat = _read_expr(expr)
+        if dat:
+            if dat["name"] == "parameters" and ret["parameters"]:
+                msg = f"Duplicate call to 'parameters()' on line {expr.lineno}"
+                raise Exception(msg)
+            ret["parameters"].append(dat["data"])
+    ret["parameters"] = ret["parameters"][0] if ret["parameters"] else {}
+    return ret
+
+
+def _read_expr(expr):
+    if isinstance(expr, ast.Assign):
+        return _read_expr(expr.value)
+    if _is_orderly_call(expr):
+        if expr.value.func.attr == "parameters":
+            return _read_parameters(expr.value)
+        return None
+    return None
+
+
+def _is_orderly_call(expr):
+    if not isinstance(expr, ast.Expr):
+        return False
+    if not isinstance(expr.value, ast.Call):
+        return False
+    call = expr.value
+    return call.func.value.id == "orderly" and call.func.attr
+
+
+def _read_parameters(call):
+    if call.args:
+        msg = "All arguments to 'parameters()' must be named"
+        raise Exception(msg)
+    data = {}
+    for kw in call.keywords:
+        nm = kw.arg
+        value = kw.value
+        if nm in data:
+            msg = f"Duplicate argument '{nm}' to 'parameters()'"
+            raise Exception(msg)
+        if not isinstance(value, ast.Constant):
+            msg = f"Invalid value for argument '{nm}' to 'parameters()': {ast.unparse(value)}"
+            raise Exception(msg)
+        data[nm] = kw.value.value
+    return {"name": "parameters", "data": data}

--- a/src/orderly/read.py
+++ b/src/orderly/read.py
@@ -59,7 +59,7 @@ def _read_parameters(call):
             msg = f"Duplicate argument '{nm}' to 'parameters()'"
             raise Exception(msg)
         if not isinstance(value, ast.Constant):
-            msg = f"Invalid value for argument '{nm}' to 'parameters()': {ast.unparse(value)}"
+            msg = f"Invalid value for argument '{nm}' to 'parameters()'"
             raise Exception(msg)
         data[nm] = kw.value.value
     return {"name": "parameters", "data": data}

--- a/src/orderly/read.py
+++ b/src/orderly/read.py
@@ -51,6 +51,9 @@ def _read_parameters(call):
     data = {}
     for kw in call.keywords:
         nm = kw.arg
+        if kw.arg is None:
+            msg = "Passing parameters as **kwargs is not supported"
+            raise Exception(msg)
         value = kw.value
         if nm in data:
             msg = f"Duplicate argument '{nm}' to 'parameters()'"

--- a/src/orderly/read.py
+++ b/src/orderly/read.py
@@ -2,8 +2,7 @@ import ast
 
 
 def orderly_read(path):
-    with open(path) as f:
-        src = ast.parse(f.read())
+    src = ast.parse(path.read_text())
     return _read_py(src)
 
 

--- a/src/orderly/read.py
+++ b/src/orderly/read.py
@@ -1,4 +1,10 @@
 import ast
+from dataclasses import dataclass
+
+
+@dataclass
+class ParametersCall:
+    value: ...
 
 
 def orderly_read(path):
@@ -18,11 +24,11 @@ def _read_py(src):
     ret = {"parameters": []}
     for expr in src.body:
         dat = _read_expr(expr)
-        if dat and dat["name"] == "parameters":
+        if dat and isinstance(dat, ParametersCall):
             if ret["parameters"]:
                 msg = f"Duplicate call to 'parameters()' on line {expr.lineno}"
                 raise Exception(msg)
-            ret["parameters"].append(dat["data"])
+            ret["parameters"].append(dat.value)
     ret["parameters"] = ret["parameters"][0] if ret["parameters"] else {}
     return ret
 
@@ -62,7 +68,7 @@ def _read_parameters(call):
             msg = f"Invalid value for argument '{nm}' to 'parameters()'"
             raise Exception(msg)
         data[nm] = kw.value.value
-    return {"name": "parameters", "data": data}
+    return ParametersCall(data)
 
 
 def _is_valid_parameter_value(value):

--- a/src/orderly/read.py
+++ b/src/orderly/read.py
@@ -58,8 +58,14 @@ def _read_parameters(call):
         if nm in data:
             msg = f"Duplicate argument '{nm}' to 'parameters()'"
             raise Exception(msg)
-        if not isinstance(value, ast.Constant):
+        if not _is_valid_parameter_value(value):
             msg = f"Invalid value for argument '{nm}' to 'parameters()'"
             raise Exception(msg)
         data[nm] = kw.value.value
     return {"name": "parameters", "data": data}
+
+
+def _is_valid_parameter_value(value):
+    if not isinstance(value, ast.Constant):
+        return False
+    return value.value is None or isinstance(value.value, (float, int, str))

--- a/src/orderly/read.py
+++ b/src/orderly/read.py
@@ -1,10 +1,11 @@
 import ast
 from dataclasses import dataclass
+from typing import Any
 
 
 @dataclass
 class ParametersCall:
-    value: ...
+    value: Any
 
 
 def orderly_read(path):

--- a/src/orderly/read.py
+++ b/src/orderly/read.py
@@ -18,8 +18,8 @@ def _read_py(src):
     ret = {"parameters": []}
     for expr in src.body:
         dat = _read_expr(expr)
-        if dat:
-            if dat["name"] == "parameters" and ret["parameters"]:
+        if dat and dat["name"] == "parameters":
+            if ret["parameters"]:
                 msg = f"Duplicate call to 'parameters()' on line {expr.lineno}"
                 raise Exception(msg)
             ret["parameters"].append(dat["data"])
@@ -28,8 +28,6 @@ def _read_py(src):
 
 
 def _read_expr(expr):
-    if isinstance(expr, ast.Assign):
-        return _read_expr(expr.value)
     if _is_orderly_call(expr):
         if expr.value.func.attr == "parameters":
             return _read_parameters(expr.value)

--- a/src/orderly/run.py
+++ b/src/orderly/run.py
@@ -70,8 +70,8 @@ def _validate_parameters(given, defaults):
         msg = "Parameters given, but none declared"
         raise Exception(msg)
 
-    required = [k for k, v in defaults.items() if v is None]
-    missing = set(required).difference(given.keys())
+    required = {k for k, v in defaults.items() if v is None}
+    missing = required.difference(given.keys())
     if missing:
         msg = f"Missing parameters: {', '.join(missing)}"
         raise Exception(msg)

--- a/src/orderly/run.py
+++ b/src/orderly/run.py
@@ -84,7 +84,7 @@ def _validate_parameters(given, defaults):
     ret = defaults.copy()
 
     for k, v in given.items():
-        if type(v) not in [bool, int, float, str]:
+        if isinstance(v, (int, float, str)):
             msg = f"Expected parameter {k} to be a simple value"
             raise Exception(msg)
         ret[k] = v

--- a/src/orderly/run.py
+++ b/src/orderly/run.py
@@ -84,7 +84,7 @@ def _validate_parameters(given, defaults):
     ret = defaults.copy()
 
     for k, v in given.items():
-        if isinstance(v, (int, float, str)):
+        if not isinstance(v, (int, float, str)):
             msg = f"Expected parameter {k} to be a simple value"
             raise Exception(msg)
         ret[k] = v

--- a/src/orderly/run.py
+++ b/src/orderly/run.py
@@ -78,7 +78,7 @@ def _validate_parameters(given, defaults):
 
     extra = set(given.keys()).difference(defaults.keys())
     if extra:
-        msg = f"Unknown parameters: {', '.join(missing)}"
+        msg = f"Unknown parameters: {', '.join(extra)}"
         raise Exception(msg)
 
     ret = defaults.copy()

--- a/src/orderly/run.py
+++ b/src/orderly/run.py
@@ -2,16 +2,20 @@ import shutil
 
 from orderly.core import Description
 from orderly.current import ActiveOrderlyContext
+from orderly.read import orderly_read
 from outpack.ids import outpack_id
 from outpack.packet import Packet
 from outpack.root import root_open
 from outpack.util import run_script
 
 
-def orderly_run(name, *, root=None, locate=True):
+def orderly_run(name, *, parameters=None, root=None, locate=True):
     root = root_open(root, locate=locate)
 
     path_src = _validate_src_directory(name, root)
+
+    dat = orderly_read(path_src / "orderly.py")
+    envir = _validate_parameters(parameters, dat["parameters"])
 
     packet_id = outpack_id()
     path_dest = root.path / "draft" / name / packet_id
@@ -19,11 +23,13 @@ def orderly_run(name, *, root=None, locate=True):
 
     _copy_resources_implicit(path_src, path_dest)
 
-    packet = Packet(root, path_dest, name, id=packet_id, locate=False)
+    packet = Packet(
+        root, path_dest, name, id=packet_id, locate=False, parameters=envir
+    )
     try:
         with ActiveOrderlyContext(packet, path_src) as orderly:
             packet.mark_file_immutable("orderly.py")
-            run_script(path_dest, "orderly.py")
+            run_script(path_dest, "orderly.py", envir)
     except Exception as error:
         _orderly_cleanup_failure(packet)
         # This is pretty barebones for now; we will need to do some
@@ -54,6 +60,36 @@ def _validate_src_directory(name, root):
         msg = f"{msg}\n* {detail}"
         raise Exception(msg)
     return path
+
+
+def _validate_parameters(given, defaults):
+    if given is None:
+        given = {}
+
+    if given and not defaults:
+        msg = "Parameters given, but none declared"
+        raise Exception(msg)
+
+    required = [k for k, v in defaults.items() if v is None]
+    missing = set(required).difference(given.keys())
+    if missing:
+        msg = f"Missing parameters: {', '.join(missing)}"
+        raise Exception(msg)
+
+    extra = set(given.keys()).difference(defaults.keys())
+    if extra:
+        msg = f"Unknown parameters: {', '.join(missing)}"
+        raise Exception(msg)
+
+    ret = defaults.copy()
+
+    for k, v in given.items():
+        if type(v) not in [bool, int, float, str]:
+            msg = f"Expected parameter {k} to be a simple value"
+            raise Exception(msg)
+        ret[k] = v
+
+    return ret
 
 
 def _copy_resources_implicit(src, dest):

--- a/src/outpack/util.py
+++ b/src/outpack/util.py
@@ -41,11 +41,11 @@ def all_normal_files(path):
     ]
 
 
-def run_script(wd, path):
+def run_script(wd, path, init_globals):
     with transient_working_directory(wd):
         # other ways to do this include importlib, subprocess and
         # multiprocess
-        runpy.run_path(path)
+        runpy.run_path(path, init_globals=init_globals)
 
 
 @contextmanager

--- a/tests/orderly/examples/parameters/orderly.py
+++ b/tests/orderly/examples/parameters/orderly.py
@@ -1,5 +1,8 @@
 import orderly
 
+# We'll rethink this strategy soon
+# ruff: noqa: F821
+
 orderly.parameters(a=1, b=None)
 with open("result.txt", "w") as f:
-    f.write(f"a: {a}\nb: {b}\n")  # noqa: F821
+    f.write(f"a: {a}\nb: {b}\n")  # type: ignore

--- a/tests/orderly/examples/parameters/orderly.py
+++ b/tests/orderly/examples/parameters/orderly.py
@@ -2,4 +2,4 @@ import orderly
 
 orderly.parameters(a=1, b=None)
 with open("result.txt", "w") as f:
-    f.write(f"a: {a}\nb: {b}\n")
+    f.write(f"a: {a}\nb: {b}\n")  # noqa: F821

--- a/tests/orderly/examples/parameters/orderly.py
+++ b/tests/orderly/examples/parameters/orderly.py
@@ -1,0 +1,5 @@
+import orderly
+
+orderly.parameters(a=1, b=None)
+with open("result.txt", "w") as f:
+    f.write(f"a: {a}\nb: {b}\n")

--- a/tests/orderly/test_read.py
+++ b/tests/orderly/test_read.py
@@ -1,4 +1,5 @@
 import ast
+from pathlib import Path
 import re
 import sys
 
@@ -45,10 +46,10 @@ def test_prevent_multiple_calls_to_parameters():
 
 
 def test_can_read_orderly_py_with_no_parameters():
-    path = "tests/orderly/examples/data/orderly.py"
+    path = Path("tests/orderly/examples/data/orderly.py")
     assert orderly_read(path) == {"parameters": {}}
 
 
 def test_can_read_orderly_py_with_parameters():
-    path = "tests/orderly/examples/parameters/orderly.py"
+    path = Path("tests/orderly/examples/parameters/orderly.py")
     assert orderly_read(path) == {"parameters": {"a": 1, "b": None}}

--- a/tests/orderly/test_read.py
+++ b/tests/orderly/test_read.py
@@ -53,3 +53,16 @@ def test_can_read_orderly_py_with_no_parameters():
 def test_can_read_orderly_py_with_parameters():
     path = Path("tests/orderly/examples/parameters/orderly.py")
     assert orderly_read(path) == {"parameters": {"a": 1, "b": None}}
+
+
+def test_throw_nice_error_with_kwargs():
+    code = """
+pars = {
+  "x": 0,
+  "y": False
+}
+orderly.parameters(**pars)
+"""
+    msg = re.escape("Passing parameters as **kwargs is not supported")
+    with pytest.raises(Exception, match=msg):
+        res = _read_py(ast.parse(code))

--- a/tests/orderly/test_read.py
+++ b/tests/orderly/test_read.py
@@ -1,0 +1,48 @@
+import ast
+import re
+
+import pytest
+from orderly.read import _read_py, orderly_read
+
+
+def test_read_simple_trivial_parameters():
+    assert _read_py(ast.parse("orderly.parameters()")) == {"parameters": {}}
+    a = _read_py(ast.parse("orderly.parameters(a=None)"))
+    assert a == {"parameters": {"a": None}}
+    ab = _read_py(ast.parse("orderly.parameters(a=None, b=1)"))
+    assert ab == {"parameters": {"a": None, "b": 1}}
+
+
+def test_prevent_complex_types_in_parameters():
+    msg = "Invalid value for argument 'a' to 'parameters()': len"
+    with pytest.raises(Exception, match=re.escape(msg)):
+        _read_py(ast.parse("orderly.parameters(a=len)"))
+
+
+def test_prevent_duplicate_arguments():
+    msg = "Duplicate argument 'a' to 'parameters()'"
+    with pytest.raises(Exception, match=re.escape(msg)):
+        _read_py(ast.parse("orderly.parameters(a=1, a=2, b=2)"))
+
+
+def test_require_named_arguments():
+    msg = "All arguments to 'parameters()' must be named"
+    with pytest.raises(Exception, match=re.escape(msg)):
+        _read_py(ast.parse("orderly.parameters(1, a=2, b=2)"))
+
+
+def test_prevent_multiple_calls_to_parameters():
+    code = "orderly.parameters(a=1, b=2)\norderly.parameters(c=3)"
+    msg = "Duplicate call to 'parameters()' on line 2"
+    with pytest.raises(Exception, match=re.escape(msg)):
+        _read_py(ast.parse(code))
+
+
+def test_can_read_orderly_py_with_no_parameters():
+    path = "tests/orderly/examples/data/orderly.py"
+    assert orderly_read(path) == {"parameters": {}}
+
+
+def test_can_read_orderly_py_with_parameters():
+    path = "tests/orderly/examples/parameters/orderly.py"
+    assert orderly_read(path) == {"parameters": {"a": 1, "b": None}}

--- a/tests/orderly/test_read.py
+++ b/tests/orderly/test_read.py
@@ -1,7 +1,7 @@
 import ast
-from pathlib import Path
 import re
 import sys
+from pathlib import Path
 
 import pytest
 from orderly.read import _read_py, orderly_read
@@ -65,4 +65,4 @@ orderly.parameters(**pars)
 """
     msg = re.escape("Passing parameters as **kwargs is not supported")
     with pytest.raises(Exception, match=msg):
-        res = _read_py(ast.parse(code))
+        _read_py(ast.parse(code))

--- a/tests/orderly/test_read.py
+++ b/tests/orderly/test_read.py
@@ -1,5 +1,6 @@
 import ast
 import re
+import sys
 
 import pytest
 from orderly.read import _read_py, orderly_read
@@ -18,11 +19,12 @@ def test_skip_over_uninteresting_calls():
 
 
 def test_prevent_complex_types_in_parameters():
-    msg = "Invalid value for argument 'a' to 'parameters()': len"
+    msg = "Invalid value for argument 'a' to 'parameters()'"
     with pytest.raises(Exception, match=re.escape(msg)):
         _read_py(ast.parse("orderly.parameters(a=len)"))
 
 
+@pytest.mark.skipif(sys.version_info < (3, 9), reason="requires 3.9 or later")
 def test_prevent_duplicate_arguments():
     msg = "Duplicate argument 'a' to 'parameters()'"
     with pytest.raises(Exception, match=re.escape(msg)):

--- a/tests/orderly/test_read.py
+++ b/tests/orderly/test_read.py
@@ -13,6 +13,10 @@ def test_read_simple_trivial_parameters():
     assert ab == {"parameters": {"a": None, "b": 1}}
 
 
+def test_skip_over_uninteresting_calls():
+    assert _read_py(ast.parse("1")) == {"parameters": {}}
+
+
 def test_prevent_complex_types_in_parameters():
     msg = "Invalid value for argument 'a' to 'parameters()': len"
     with pytest.raises(Exception, match=re.escape(msg)):

--- a/tests/orderly/test_run.py
+++ b/tests/orderly/test_run.py
@@ -208,3 +208,14 @@ def test_can_run_simple_dependency(tmp_path):
     assert len(meta.depends[0].files)
     assert meta.depends[0].files[0].here == "input.txt"
     assert meta.depends[0].files[0].there == "result.txt"
+
+
+def test_can_run_with_parameters(tmp_path):
+    helpers.create_orderly_root(tmp_path, ["parameters"])
+    id = orderly_run("parameters", parameters={"b": 2}, root=tmp_path)
+    with open(tmp_path / "archive" / "parameters" / id / "result.txt") as f:
+        result = f.read()
+    assert result == "a: 1\nb: 2\n"
+    meta = root_open(tmp_path, False).index.metadata(id)
+    assert meta.parameters == {"a": 1, "b": 2}
+

--- a/tests/orderly/test_run.py
+++ b/tests/orderly/test_run.py
@@ -241,8 +241,7 @@ def test_can_validate_parameters():
         _validate_parameters({}, {"a": 1, "b": None})
     with pytest.raises(Exception, match="Unknown parameters: b$"):
         _validate_parameters({"b": 1}, {"a": 1})
-    with pytest.raises(
-        Exception, match="Expected parameter a to be a simple value"
-    ):
+    err = "Expected parameter a to be a simple value"
+    with pytest.raises(Exception, match=err):
         _validate_parameters({"a": str}, {"a": 1})
 

--- a/tests/orderly/test_run.py
+++ b/tests/orderly/test_run.py
@@ -215,12 +215,13 @@ def test_can_run_simple_dependency(tmp_path):
 
 
 def test_can_run_with_parameters(tmp_path):
-    helpers.create_orderly_root(tmp_path, ["parameters"])
+    root = helpers.create_temporary_root(tmp_path)
+    helpers.copy_examples(["parameters"], root)
     id = orderly_run("parameters", parameters={"b": 2}, root=tmp_path)
     with open(tmp_path / "archive" / "parameters" / id / "result.txt") as f:
         result = f.read()
     assert result == "a: 1\nb: 2\n"
-    meta = root_open(tmp_path, False).index.metadata(id)
+    meta = root.index.metadata(id)
     assert meta.parameters == {"a": 1, "b": 2}
 
 

--- a/tests/orderly/test_run.py
+++ b/tests/orderly/test_run.py
@@ -244,4 +244,3 @@ def test_can_validate_parameters():
     err = "Expected parameter a to be a simple value"
     with pytest.raises(Exception, match=err):
         _validate_parameters({"a": str}, {"a": 1})
-

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -11,6 +11,7 @@ from outpack.util import (
     match_value,
     num_to_time,
     read_string,
+    run_script,
     time_to_num,
 )
 
@@ -103,3 +104,14 @@ def test_read_string(tmp_path):
         f.writelines(lines)
 
     assert read_string(path) == "  this is my first  line\t  this is the second"
+
+
+def test_can_inject_data_into_run(tmp_path):
+    lines = ["with open('result.txt', 'w') as f:\n" "  f.write(str(a))\n"]
+    path = tmp_path / "script.py"
+    with open(path, "w") as f:
+        f.writelines(lines)
+    run_script(tmp_path, "script.py", {"a": "hello"})
+    assert tmp_path.joinpath("result.txt").exists()
+    with open(tmp_path.joinpath("result.txt")) as f:
+        assert f.read() == "hello"

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -107,7 +107,7 @@ def test_read_string(tmp_path):
 
 
 def test_can_inject_data_into_run(tmp_path):
-    lines = ["with open('result.txt', 'w') as f:\n" "  f.write(str(a))\n"]
+    lines = ["with open('result.txt', 'w') as f:\n  f.write(str(a))\n"]
     path = tmp_path / "script.py"
     with open(path, "w") as f:
         f.writelines(lines)


### PR DESCRIPTION
Pretty basic atm - this PR just implements `orderly.parameters()` which we never actually run! Instead we read the `orderly.py` before running anything in order to work out which parameters are required/accepted, validating this, modifying the defaults and then passing these in to create the eventual packet. 

There's work not done here around what to do in an interactive session; in the R version we check the global environment (`.GlobalEnv`) but this is not obviously possible in python, though I'm sure it can be done. We could also look in the calling environment of `orderly.parameters()` but I've not set that up yet. Instead I suggest we look at all the interactive experience somewhat together as a whole later.