### PR TITLE
Include both outpack and orderly packages when building wheels.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -48,6 +48,10 @@ jobs:
       - name: Lint
         run: |
           hatch run lint:all
+      - name: Test install
+        run: |
+          pip install .
+          python -c "import orderly; import outpack"
       - name: Upload to Codecov
         uses: codecov/codecov-action@v3
         with:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,9 @@ Source = "https://github.com/mrc-ide/outpack"
 [tool.hatch.version]
 path = "src/outpack/__about__.py"
 
+[tool.hatch.build.targets.wheel]
+packages = ["src/outpack", "src/orderly"]
+
 [tool.hatch.envs.default]
 dependencies = [
   "coverage[toml]>=6.5",


### PR DESCRIPTION
When installing this repo with pip, it would only install the outpack package, not the orderly one. It seems that by default, hatch looks for `src/$PROJECT_NAME` to figure out what to build, which in our case is just the outpack package.

Thankfully it offers an override that allows multiple package paths to be listed, which we can use to include the two packages.