### PR TITLE
Check if function call is of the right form before inspecting it.

### DIFF
--- a/src/orderly/read.py
+++ b/src/orderly/read.py
@@ -47,7 +47,13 @@ def _is_orderly_call(expr):
         return False
     if not isinstance(expr.value, ast.Call):
         return False
+
     call = expr.value
+    if not isinstance(call.func, ast.Attribute):
+        return False
+    if not isinstance(call.func.value, ast.Name):
+        return False
+
     return call.func.value.id == "orderly" and call.func.attr
 
 

--- a/tests/orderly/test_read.py
+++ b/tests/orderly/test_read.py
@@ -15,8 +15,17 @@ def test_read_simple_trivial_parameters():
     assert ab == {"parameters": {"a": None, "b": 1}}
 
 
-def test_skip_over_uninteresting_calls():
-    assert _read_py(ast.parse("1")) == {"parameters": {}}
+def test_skip_over_uninteresting_code():
+    code = '''
+def foo():
+    pass
+1
+parameters(a=1)
+print("Hello, World")
+foo()
+foo().parameters()
+'''
+    assert _read_py(ast.parse(code)) == {"parameters": {}}
 
 
 def test_prevent_complex_types_in_parameters():

--- a/tests/orderly/test_read.py
+++ b/tests/orderly/test_read.py
@@ -16,7 +16,7 @@ def test_read_simple_trivial_parameters():
 
 
 def test_skip_over_uninteresting_code():
-    code = '''
+    code = """
 def foo():
     pass
 1
@@ -24,7 +24,7 @@ parameters(a=1)
 print("Hello, World")
 foo()
 foo().parameters()
-'''
+"""
     assert _read_py(ast.parse(code)) == {"parameters": {}}
 
 


### PR DESCRIPTION
The orderly_read feature scans the input file looking for calls to `orderly.XXX` functions. Whenever it sees a function call it was assuming it was in the form of an attribute lookup and would check if the name of the part before the dot was equal to `orderly`.

This would crash if the method call was not on an attribute (eg. a simple `print(...)` call), or if the part before the dot is not a simple identifier (eg. a chained attribute lookup, or anything more complicated).

This checks the type of the AST nodes more precisely to catch these cases.