### PR TITLE
Sort the list of IDs before comparing it.

### DIFF
--- a/tests/test_location_pull.py
+++ b/tests/test_location_pull.py
@@ -631,7 +631,7 @@ def test_if_recursive_pulls_are_required_pulls_are_default_recursive(tmp_path):
     assert root["shallow"].index.unpacked() == [ids["c"]]
 
     outpack_location_pull_packet(ids["c"], recursive=None, root=root["deep"])
-    assert root["deep"].index.unpacked() == list(ids.values())
+    assert root["deep"].index.unpacked() == sorted(ids.values())
 
 
 ## TODO: Uncomment when wired up with searching

--- a/tests/test_packet.py
+++ b/tests/test_packet.py
@@ -1,5 +1,3 @@
-import time
-
 import pytest
 
 from outpack.init import outpack_init
@@ -99,12 +97,12 @@ def test_can_insert_a_packet_into_existing_root(tmp_path):
 
     p1 = Packet(root, src, "data")
     p1.end()
-    time.sleep(0.01)  # windows time resolution not good enough
+
     p2 = Packet(root, src, "data")
     p2.end()
 
     r = root_open(root)
-    assert r.index.unpacked() == [p1.id, p2.id]
+    assert r.index.unpacked() == sorted([p1.id, p2.id])
 
 
 def test_can_add_custom_metadata(tmp_path):


### PR DESCRIPTION
The list of packet IDs returned by `unpacked()` is always sorted lexicographically. Some tests were assuming that this was the same as packet creation order, and were comparing the list of packets against another value for equality.

However, if the packets were created very closely is time, the timestamp part of their packet ID may be equal, in which case the relative order is determined by the random bytes added to the packets. In that case, lexicographical order may not match packet creation order. This is especially likely on Windows where the timer resolution is quite coarse.