### PR TITLE
Run reports in a separate Python process.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,8 @@ dependencies = [
   "jsonschema",
   "pygit2",
   "outpack-query-parser",
-  "humanize"
+  "humanize",
+  "tblib"
 ]
 
 [project.urls]
@@ -213,4 +214,8 @@ ignore_missing_imports = true
 
 [[tool.mypy.overrides]]
 module = "outpack_query_parser"
+ignore_missing_imports = true
+
+[[tool.mypy.overrides]]
+module = "tblib"
 ignore_missing_imports = true

--- a/src/outpack/sandbox.py
+++ b/src/outpack/sandbox.py
@@ -1,0 +1,79 @@
+import os
+import pickle
+import subprocess
+import sys
+
+from tblib import pickling_support
+
+from outpack.util import openable_temporary_file
+
+
+def run_in_sandbox(target, args=(), cwd=None, syspath=None):
+    """
+    Run a function as a separate process.
+
+    The function, its arguments and return value must be picklable.
+
+    Parameters
+    ----------
+    target:
+        The function to run in the subprocess. This function must be accessible
+        by name from the top level of a module in order to be pickled.
+    args:
+        The arguments to be passed to the function
+    cwd:
+        The working directory in which the subprocess runs. If None, it inherits
+        the current process' working directory.
+    syspath:
+        A list of paths to be added to the child process' Python search path.
+        This is used when the target function's module is not globally
+        available.
+    """
+    with openable_temporary_file() as input_file:
+        with openable_temporary_file(mode="rb") as output_file:
+            pickle.dump((target, args), input_file)
+            input_file.flush()
+
+            cmd = [
+                sys.executable,
+                "-m",
+                "outpack.sandbox",
+                input_file.name,
+                output_file.name,
+            ]
+
+            if syspath is not None:
+                env = os.environ.copy()
+                pythonpath = ":".join(str(s) for s in syspath)
+
+                if "PYTHONPATH" in env:
+                    env["PYTHONPATH"] = f"{pythonpath}:{env['PYTHONPATH']}"
+                else:
+                    env["PYTHONPATH"] = pythonpath
+            else:
+                env = None
+
+            p = subprocess.run(cmd, cwd=cwd, env=env, check=False)  # noqa: S603
+            p.check_returncode()
+
+            (ok, value) = pickle.load(output_file)  # noqa: S301
+            if ok:
+                return value
+            else:
+                raise value
+
+
+if __name__ == "__main__":
+    with open(sys.argv[1], "rb") as input_file:
+        (target, args) = pickle.load(input_file)  # noqa: S301
+
+    try:
+        result = (True, target(*args))
+    except BaseException as e:
+        # This allows the traceback to be pickled and communicated out of the
+        # the sandbox.
+        pickling_support.install(e)
+        result = (False, e)
+
+    with open(sys.argv[2], "wb") as output_file:
+        pickle.dump(result, output_file)

--- a/src/outpack/util.py
+++ b/src/outpack/util.py
@@ -1,6 +1,5 @@
 import datetime
 import os
-import runpy
 import tempfile
 import time
 from contextlib import contextmanager
@@ -47,15 +46,6 @@ def all_normal_files(path):
         if "__pycache__" in dirs:
             dirs.remove("__pycache__")
     return result
-
-
-def run_script(wd, path, init_globals):
-    with transient_working_directory(wd):
-        # other ways to do this include importlib, subprocess and
-        # multiprocess
-        runpy.run_path(
-            str(wd / path), init_globals=init_globals, run_name="__main__"
-        )
 
 
 @contextmanager

--- a/tests/orderly/examples/imports/helpers.py
+++ b/tests/orderly/examples/imports/helpers.py
@@ -1,0 +1,2 @@
+def get_description():
+    return "Hello from module"

--- a/tests/orderly/examples/imports/imports.py
+++ b/tests/orderly/examples/imports/imports.py
@@ -1,0 +1,4 @@
+import orderly
+from helpers import get_description  # type: ignore
+
+orderly.description(display=get_description())

--- a/tests/orderly/test_run.py
+++ b/tests/orderly/test_run.py
@@ -372,6 +372,39 @@ def test_can_use_shared_resources_directory(tmp_path):
     }
 
 
+def test_can_import_module_in_report(tmp_path):
+    root = helpers.create_temporary_root(tmp_path)
+    helpers.copy_examples(["imports"], root)
+
+    id = orderly_run("imports", root=root)
+
+    desc = root.index.metadata(id).custom["orderly"]["description"]["display"]
+    assert desc == "Hello from module"
+
+
+def test_imported_modules_are_not_persisted(tmp_path):
+    root = helpers.create_temporary_root(tmp_path)
+    helpers.copy_examples(["imports"], root)
+
+    id1 = orderly_run("imports", root=root)
+
+    with open(tmp_path / "src" / "imports" / "helpers.py", "w") as f:
+        f.writelines(
+            """
+def get_description():
+    return "Description has been changed"
+"""
+        )
+
+    id2 = orderly_run("imports", root=root)
+
+    desc1 = root.index.metadata(id1).custom["orderly"]["description"]["display"]
+    assert desc1 == "Hello from module"
+
+    desc2 = root.index.metadata(id2).custom["orderly"]["description"]["display"]
+    assert desc2 == "Description has been changed"
+
+
 def test_can_validate_parameters():
     assert _validate_parameters({}, {}) == {}
     assert _validate_parameters(None, {}) == {}

--- a/tests/test_location_pull.py
+++ b/tests/test_location_pull.py
@@ -22,7 +22,6 @@ from outpack.location_pull import (
     outpack_location_pull_metadata,
     outpack_location_pull_packet,
 )
-from outpack.packet import Packet
 from outpack.search_options import SearchOptions
 from outpack.util import read_string
 
@@ -375,17 +374,12 @@ def test_detect_and_avoid_modified_files_in_source_repository(tmp_path):
         tmp_path, add_location=True, use_file_store=False
     )
 
-    tmp_dir = tmp_path / "new_dir"
-    os.mkdir(tmp_dir)
-    with open(tmp_dir / "a.txt", "w") as f:
-        f.writelines("my data a")
-    with open(tmp_dir / "b.txt", "w") as f:
-        f.writelines("my data b")
-    ids = [None] * 2
-    for i in range(len(ids)):
-        p = Packet(root["src"], tmp_dir, "data")
-        p.end()
-        ids[i] = p.id
+    ids = []
+    for _ in range(2):
+        with create_packet(root["src"], "data") as p:
+            (p.path / "a.txt").write_text("my data a")
+            (p.path / "b.txt").write_text("my data b")
+        ids.append(p.id)
 
     outpack_location_pull_metadata(root=root["dst"])
 

--- a/tests/test_sandbox.py
+++ b/tests/test_sandbox.py
@@ -1,0 +1,120 @@
+import os
+import time
+from pathlib import Path
+from traceback import TracebackException
+
+import pytest
+
+from outpack.sandbox import run_in_sandbox
+
+
+def sandbox_returns_value():
+    return 42
+
+
+def test_sandbox_returns_value():
+    assert run_in_sandbox(sandbox_returns_value) == 42
+
+
+def sandbox_accepts_arguments(x, y):
+    return x * y
+
+
+def test_sandbox_accepts_arguments():
+    result = run_in_sandbox(sandbox_accepts_arguments, args=(42, 2))
+    assert result == 84
+
+
+def sandbox_propagates_exceptions():
+    msg = "something bad"
+    raise Exception(msg)
+
+
+def test_sandbox_propagates_exceptions():
+    with pytest.raises(Exception, match="something bad"):
+        run_in_sandbox(sandbox_propagates_exceptions)
+
+
+def test_sandbox_propagates_tracebacks():
+    with pytest.raises(Exception, match="something bad") as e:
+        run_in_sandbox(sandbox_propagates_exceptions)
+
+    tb = TracebackException(e.type, e.value, e.tb)
+    assert Path(tb.stack[-1].filename).name == "test_sandbox.py"
+    assert tb.stack[-1].name == "sandbox_propagates_exceptions"
+
+
+def sandbox_does_not_share_globals():
+    global my_very_unique_name  # noqa: PLW0603
+    my_very_unique_name = 42
+    assert "my_very_unique_name" in globals()
+
+
+def test_sandbox_does_not_share_globals():
+    run_in_sandbox(sandbox_does_not_share_globals)
+    assert "my_very_unique_name" not in globals()
+
+
+def sandbox_can_run_in_different_directory():
+    return (Path.cwd(), Path("hello.txt").read_text())
+
+
+def test_sandbox_can_run_in_different_directory(tmp_path):
+    tmp_path.joinpath("hello.txt").write_text("Hello")
+
+    # The syspath is necessary for the sandbox to find the test file after we've
+    # changed working directory. In real code we don't need it as outpack is in
+    # the search path already.
+    result = run_in_sandbox(
+        sandbox_can_run_in_different_directory,
+        cwd=tmp_path,
+        syspath=[Path.cwd()],
+    )
+
+    assert result[0] == tmp_path
+    assert result[1] == "Hello"
+
+
+def sandbox_can_import_local_modules():
+    import my_unique_module_name  # type: ignore
+
+    return my_unique_module_name.hello()
+
+
+def test_sandbox_can_import_local_modules(tmp_path):
+    (tmp_path / "my_unique_module_name.py").write_text(
+        "def hello(): return 'Hello'"
+    )
+
+    result = run_in_sandbox(
+        sandbox_can_import_local_modules, cwd=tmp_path, syspath=[Path.cwd()]
+    )
+    assert result == "Hello"
+
+
+def sandbox_does_not_share_modules_cache():
+    import my_unique_module_name
+
+    return my_unique_module_name.MESSAGE
+
+
+def test_sandbox_does_not_share_modules_cache(tmp_path):
+    module = tmp_path / "my_unique_module_name.py"
+    module.write_text("MESSAGE = 'Hello'")
+
+    # Python uses modification time to invalidate the __pycache__ directory it
+    # creates. If we write to the module twice in short succession, it may have
+    # the same timestamp and not get invalidated correctly. We set the first
+    # timestamp 10 seconds in the past to avoid this.
+    os.utime(module, (time.time() - 10, time.time() - 10))
+
+    message = run_in_sandbox(
+        sandbox_does_not_share_modules_cache, cwd=tmp_path, syspath=[Path.cwd()]
+    )
+    assert message == "Hello"
+
+    module.write_text("MESSAGE = 'World'")
+    message = run_in_sandbox(
+        sandbox_does_not_share_modules_cache, cwd=tmp_path, syspath=[Path.cwd()]
+    )
+    assert message == "World"


### PR DESCRIPTION
The runpy module we've been using to run reports provides very little isolation. In particular, "any side effects (such as cached imports of other modules) will remain in place after the functions have returned". This means that if a user splits their report into multiple files, with one file importing another, the latter will be cached and never reloaded by Python, even if it is modified. Similarly, if the module was already loaded before, the report runs against old code that does not match the files included in the packet.

Using a separate subprocess gives us a much stronger isolation, including all global variables and not sharing any of previously loaded modules. It means a user can run a report, modify some of the imported code, run the report again and have this behave as expected.

The Packet class is refactored a little and its scope is reduced to just creating the packet and its metadata, without inserting it into the repository. The insertion is now handled by a separate function. This is done as a way of distinguishing what happens in the child process and what happens in the parent.