### PR TITLE
Exclude pycache when copying packet inputs and outputs.

### DIFF
--- a/src/orderly/run.py
+++ b/src/orderly/run.py
@@ -8,7 +8,7 @@ from orderly.read import orderly_read
 from outpack.ids import outpack_id
 from outpack.packet import Packet
 from outpack.root import root_open
-from outpack.util import run_script
+from outpack.util import all_normal_files, run_script
 
 
 def orderly_run(name, *, parameters=None, root=None, locate=True):
@@ -54,7 +54,7 @@ def _validate_src_directory(name, root) -> Tuple[Path, str]:
     entrypoint = f"{name}.py"
 
     if not path.joinpath(entrypoint).exists():
-        msg = f"Did not find orderly report '{name}"
+        msg = f"Did not find orderly report '{name}'"
         if path.is_dir():
             detail = f"The path 'src/{name}' exists but does not contain '{entrypoint}'"
         elif path.exists():
@@ -97,14 +97,10 @@ def _validate_parameters(given, defaults):
 
 
 def _copy_resources_implicit(src, dest):
-    info = {}
-    for p in src.iterdir():
-        p_rel = p.relative_to(src)
-        p_dest = dest.joinpath(p_rel)
+    for p in all_normal_files(src):
+        p_dest = dest / p
         p_dest.parent.mkdir(parents=True, exist_ok=True)
-        shutil.copy2(p, p_dest)
-        info[p_rel] = p.stat()
-    return info
+        shutil.copy2(src / p, p_dest)
 
 
 def _orderly_cleanup_success(packet, entrypoint, orderly):

--- a/src/outpack/util.py
+++ b/src/outpack/util.py
@@ -34,12 +34,17 @@ def num_to_time(x):
 
 # Recursively find all normal files below 'path', returning them
 # relative to that path.
+#
+# This excludes any files contained in a `__pycache__` directory.
 def all_normal_files(path):
-    return [
-        str(p.relative_to(path))
-        for p in Path(path).rglob("*")
-        if not p.is_dir()
-    ]
+    result = []
+    for root, dirs, files in os.walk(path):
+        base = Path(root).relative_to(path)
+        result.extend(str(base.joinpath(f)) for f in files)
+
+        if "__pycache__" in dirs:
+            dirs.remove("__pycache__")
+    return result
 
 
 def run_script(wd, path, init_globals):

--- a/src/outpack/util.py
+++ b/src/outpack/util.py
@@ -1,10 +1,12 @@
 import datetime
 import os
 import runpy
+import tempfile
 import time
 from contextlib import contextmanager
 from itertools import filterfalse, tee
 from pathlib import Path
+from typing import Optional
 
 
 def find_file_descend(filename, path):
@@ -141,3 +143,23 @@ def partition(pred, iterable):
     # partition(is_odd, range(10)) --> 1 3 5 7 9 and 0 2 4 6 8
     t1, t2 = tee(iterable)
     return list(filter(pred, t1)), list(filterfalse(pred, t2))
+
+
+@contextmanager
+def openable_temporary_file(*, mode: str = "w+b", dir: Optional[str] = None):
+    # On Windows, a NamedTemporaryFile with `delete=True` cannot be reopened,
+    # which makes its name pretty useless. On Python 3.12, a new
+    # delete_on_close flag is solves this issue, but we can't depend on that
+    # yet. This block mimicks that feature.
+    #
+    # https://bugs.python.org/issue14243
+    # https://github.com/mrc-ide/outpack-py/pull/33#discussion_r1500522877
+    f = tempfile.NamedTemporaryFile(mode=mode, dir=dir, delete=False)
+    try:
+        yield f
+    finally:
+        f.close()
+        try:
+            os.unlink(f.name)
+        except OSError:
+            pass

--- a/tests/helpers/__init__.py
+++ b/tests/helpers/__init__.py
@@ -2,7 +2,6 @@ import pickle
 import random
 import shutil
 import string
-import tempfile
 import textwrap
 from contextlib import contextmanager
 from pathlib import Path
@@ -16,6 +15,7 @@ from outpack.metadata import MetadataCore, PacketDepends
 from outpack.packet import Packet
 from outpack.root import root_open
 from outpack.schema import outpack_schema_version
+from outpack.util import openable_temporary_file
 
 
 @contextmanager
@@ -173,7 +173,7 @@ def run_snippet(name, code, root, **kwargs):
     # We work around that by returning the value out-of-band, in a temporary
     # file outside of the report's directory. That way it is completely
     # transparent to the caller
-    with tempfile.NamedTemporaryFile() as output:
+    with openable_temporary_file() as output:
         wrapped = f"""
 def body():
 {textwrap.indent(code, "    ")}

--- a/tests/helpers/__init__.py
+++ b/tests/helpers/__init__.py
@@ -1,6 +1,9 @@
+import pickle
 import random
 import shutil
 import string
+import tempfile
+import textwrap
 from contextlib import contextmanager
 from pathlib import Path
 from tempfile import TemporaryDirectory
@@ -156,6 +159,30 @@ def write_file(path, text):
 
 
 def run_snippet(name, code, root, **kwargs):
-    """Run a snippet of Python code as an Orderly report."""
-    write_file(root.path / "src" / name / f"{name}.py", code)
-    return orderly_run(name, root=root, **kwargs)
+    """
+    Run a snippet of Python code as an Orderly report.
+
+    The snippet is wrapped in a function and may use return statements. The
+    snippet's return value is returned by this function, alongside the packet
+    ID.
+    """
+    # The obvious way of returning the snippet's result would be to write it as
+    # an artefact of the packet. This is visible in the packet's metadata and
+    # would cause noise in the expectations of tests using this function.
+    #
+    # We work around that by returning the value out-of-band, in a temporary
+    # file outside of the report's directory. That way it is completely
+    # transparent to the caller
+    with tempfile.NamedTemporaryFile() as output:
+        wrapped = f"""
+def body():
+{textwrap.indent(code, "    ")}
+
+import pickle
+with open({output.name!r}, "wb") as f:
+    pickle.dump(body(), f)
+"""
+        write_file(root.path / "src" / name / f"{name}.py", wrapped)
+        id = orderly_run(name, root=root, **kwargs)
+        result = pickle.load(output)  # noqa: S301
+        return id, result

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -80,6 +80,22 @@ def test_all_normal_files_recurses(tmp_path):
     assert set(all_normal_files(tmp_path)) == expected
 
 
+def test_all_normal_files_excludes_pycache(tmp_path):
+    helpers.touch_files(
+        tmp_path / "a.txt",
+        tmp_path / "__pycache__" / "b.txt",
+        tmp_path / "__pycache__" / "a" / "c.txt",
+        tmp_path / "a" / "d.txt",
+        tmp_path / "a" / "__pycache__" / "e.txt",
+    )
+
+    expected = {
+        "a.txt",
+        os.path.join("a", "d.txt"),
+    }
+    assert set(all_normal_files(tmp_path)) == expected
+
+
 def test_can_expand_paths(tmp_path):
     helpers.touch_files(tmp_path / "a" / "x", tmp_path / "a" / "y")
     (tmp_path / "b").mkdir()


### PR DESCRIPTION
Python tends to produce a lot of `__pycache__` folders. These can be found both in a report's source directory, if the user ran the entrypoint script outside of an orderly context, and in the packet's working directory after executing the packet.

There is never a good reason to include these in packets and we can exclude them unconditionally, both when copying files in and out of a packet's working directory.

As a side-effect of now using the same function to copy files in and out of a packet, this commit also fixes the use of directory in a report's source directory. Previously we were attempting to call `shutil.copy2` on every entry, which would fail on directories.