### PR TITLE
Add a new SSH-based location.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,8 @@ dependencies = [
   "pygit2",
   "outpack-query-parser",
   "humanize",
-  "tblib"
+  "tblib",
+  "paramiko",
 ]
 
 [project.urls]

--- a/src/outpack/location_driver.py
+++ b/src/outpack/location_driver.py
@@ -1,0 +1,25 @@
+from abc import abstractmethod
+from contextlib import AbstractContextManager
+from typing import Dict, List
+
+from outpack.metadata import MetadataCore, PacketFile, PacketLocation
+
+
+class LocationDriver(AbstractContextManager):
+    """
+    A location implementation.
+
+    The driver object is treated as a context manager and is entered and exited
+    before and after its methods are called.
+    """
+
+    @abstractmethod
+    def list(self) -> Dict[str, PacketLocation]: ...
+
+    @abstractmethod
+    def metadata(self, packet_ids: List[str]) -> Dict[str, str]: ...
+
+    @abstractmethod
+    def fetch_file(
+        self, packet: MetadataCore, file: PacketFile, dest: str
+    ) -> None: ...

--- a/src/outpack/location_path.py
+++ b/src/outpack/location_path.py
@@ -2,7 +2,7 @@ import os
 import shutil
 from typing import Dict, List
 
-from outpack.location import LocationDriver
+from outpack.location_driver import LocationDriver
 from outpack.metadata import MetadataCore, PacketFile, PacketLocation
 from outpack.root import find_file_by_hash, root_open
 from outpack.static import LOCATION_LOCAL

--- a/src/outpack/location_path.py
+++ b/src/outpack/location_path.py
@@ -1,22 +1,28 @@
 import os
 import shutil
+from typing import Dict, List
 
+from outpack.location import LocationDriver
+from outpack.metadata import MetadataCore, PacketFile, PacketLocation
 from outpack.root import find_file_by_hash, root_open
 from outpack.static import LOCATION_LOCAL
 from outpack.util import read_string
 
 
-class OutpackLocationPath:
+class OutpackLocationPath(LocationDriver):
     def __init__(self, path):
         self.__root = root_open(path, locate=False)
 
-    def list(self):
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_value, exc_tb):
+        pass
+
+    def list(self) -> Dict[str, PacketLocation]:
         return self.__root.index.location(LOCATION_LOCAL)
 
-    def metadata(self, packet_ids):
-        if isinstance(packet_ids, str):
-            packet_ids = [packet_ids]
-
+    def metadata(self, packet_ids: List[str]) -> Dict[str, str]:
         all_ids = self.__root.index.location(LOCATION_LOCAL).keys()
         missing_ids = set(packet_ids).difference(all_ids)
         if missing_ids:
@@ -29,16 +35,15 @@ class OutpackLocationPath:
             ret[packet_id] = read_string(path)
         return ret
 
-    def fetch_file(self, hash, dest):
+    def fetch_file(self, _packet: MetadataCore, file: PacketFile, dest: str):
         if self.__root.config.core.use_file_store:
-            path = self.__root.files.filename(hash)
+            path = self.__root.files.filename(file.hash)
             if not os.path.exists(path):
-                msg = f"Hash '{hash}' not found at location"
+                msg = f"Hash '{file.hash}' not found at location"
                 raise Exception(msg)
         else:
-            path = find_file_by_hash(self.__root, hash)
+            path = find_file_by_hash(self.__root, file.hash)
             if path is None:
-                msg = f"Hash '{hash}' not found at location"
+                msg = f"Hash '{file.hash}' not found at location"
                 raise Exception(msg)
         shutil.copyfile(path, dest)
-        return dest

--- a/src/outpack/location_ssh.py
+++ b/src/outpack/location_ssh.py
@@ -1,0 +1,169 @@
+import base64
+import errno
+import re
+from contextlib import ExitStack
+from pathlib import PurePosixPath
+from typing import Dict, List
+from urllib.parse import urlparse
+
+import paramiko
+
+from outpack.config import Config
+from outpack.hash import hash_parse
+from outpack.location import LocationDriver
+from outpack.metadata import MetadataCore, PacketFile, PacketLocation
+from outpack.static import LOCATION_LOCAL
+
+SCP_URL = re.compile(r"((?P<username>[^@]+)@)?(?P<hostname>[^:]+):(?P<path>.*)")
+
+
+def parse_ssh_url(url):
+    """
+    Parse the URL of an SSH location.
+
+    We follow Git's definition of URLs, and support two syntaxes: a short
+    `username@hostname:path` version, inspired by the scp command, and a longer
+    more explicit `ssh://username@hostname:port/path`.
+
+    The SCP syntax doesn't support configuring a port number (though an
+    .ssh/config file can be used to work around that limitation).
+
+    By default, the path in the SCP syntax is relative to the remote user's home
+    directory, and `hostname:/foo/bar` can be used to specify an absolute path.
+    The explicit URL syntax is always absolute.
+
+    See https://git-scm.com/docs/git-pull#_git_urls.
+    """
+    if "://" in url:
+        parts = urlparse(url)
+        if parts.scheme != "ssh":
+            msg = f"Protocol of SSH url must be 'ssh', not '{parts.scheme}'"
+            raise Exception(msg)
+
+        if parts.path == "":
+            msg = "No path specified for SSH location"
+            raise Exception(msg)
+
+        return parts.username, parts.hostname, parts.port, parts.path
+
+    elif m := SCP_URL.fullmatch(url):
+        return (m.group("username"), m.group("hostname"), None, m.group("path"))
+    else:
+        msg = f"Invalid SSH url: '{url}'"
+        raise Exception(msg)
+
+
+class OutpackLocationSSH(LocationDriver):
+    _client: paramiko.SSHClient
+    _sftp: paramiko.SFTPClient
+
+    def __init__(self, url: str, known_hosts=None, password=None):
+        (username, hostname, port, path) = parse_ssh_url(url)
+        self._username = username
+        self._hostname = hostname
+        self._port = port or 22
+        self._root = PurePosixPath(path)
+        self._known_hosts = known_hosts
+        self._password = password
+        self._stack = ExitStack()
+
+    def __enter__(self):
+        with ExitStack() as stack:
+            client = stack.enter_context(paramiko.SSHClient())
+
+            if self._known_hosts is not None:
+                for hostname, keytype, data in self._known_hosts:
+                    key = paramiko.RSAKey(data=base64.b64decode(data))
+                    client.get_host_keys().add(hostname, keytype, key)
+            else:
+                client.load_system_host_keys()
+
+            client.connect(
+                self._hostname,
+                username=self._username,
+                port=self._port,
+                password=self._password,
+            )
+
+            sftp = stack.enter_context(client.open_sftp())
+
+            try:
+                sftp.stat(str(self._root))
+            except OSError as e:
+                if e.errno == errno.ENOENT:
+                    msg = f"Path '{self._root}' on remote {self._hostname} does not exist"
+                    raise Exception(msg) from None
+                else:
+                    raise
+
+            path = self._root / ".outpack" / "config.json"
+            try:
+                with sftp.open(str(path)) as f:
+                    self.config = Config.from_json(f.read().strip())  # type: ignore
+            except OSError as e:
+                if e.errno == errno.ENOENT:
+                    msg = f"Path '{self._root}' on remote {self._hostname} is not a valid outpack repository"
+                    raise Exception(msg) from None
+                else:
+                    raise
+
+            self._client = client
+            self._sftp = sftp
+            self._stack = stack.pop_all()
+
+            return self
+
+    def __exit__(self, *args):
+        return self._stack.__exit__(*args)
+
+    def list(self) -> Dict[str, PacketLocation]:
+        path = self._root / ".outpack" / "location" / LOCATION_LOCAL
+        result = {}
+        for packet in self._sftp.listdir(str(path)):
+            with self._sftp.open(str(path / packet)) as f:
+                result[packet] = PacketLocation.from_json(f.read().strip())  # type: ignore
+        return result
+
+    def metadata(self, ids: List[str]) -> Dict[str, str]:
+        path = self._root / ".outpack" / "metadata"
+        result = {}
+
+        for packet in ids:
+            with self._sftp.open(str(path / packet)) as f:
+                result[packet] = f.read().decode("ascii").strip()
+
+        return result
+
+    def fetch_file(self, packet: MetadataCore, file: PacketFile, dest: str):
+        path = self._file_path(packet, file)
+        if path is None:
+            msg = f"Hash '{file.hash}' not found at location"
+            raise Exception(msg)
+
+        try:
+            self._sftp.get(str(path), dest)
+        except OSError as e:
+            if e.errno == errno.ENOENT:
+                msg = f"Hash '{file.hash}' not found at location"
+                raise Exception(msg) from e
+            else:
+                raise
+
+    def _file_path(self, packet: MetadataCore, file: PacketFile):
+        if self.config.core.use_file_store:
+            dat = hash_parse(file.hash)
+            return (
+                self._root
+                / "files"
+                / dat.algorithm
+                / dat.value[:2]
+                / dat.value[2:]
+            )
+        else:
+            return (
+                self._root
+                / self.config.core.path_archive
+                / packet.name
+                / packet.id
+                / file.path
+            )

--- a/src/outpack/location_ssh.py
+++ b/src/outpack/location_ssh.py
@@ -130,7 +130,7 @@ class OutpackLocationSSH(LocationDriver):
 
         for packet in ids:
             with self._sftp.open(str(path / packet)) as f:
-                result[packet] = f.read().decode("ascii").strip()
+                result[packet] = f.read().decode("utf-8").strip()
 
         return result
 

--- a/src/outpack/location_ssh.py
+++ b/src/outpack/location_ssh.py
@@ -10,7 +10,7 @@ import paramiko
 
 from outpack.config import Config
 from outpack.hash import hash_parse
-from outpack.location import LocationDriver
+from outpack.location_driver import LocationDriver
 from outpack.metadata import MetadataCore, PacketFile, PacketLocation
 from outpack.static import LOCATION_LOCAL
 

--- a/src/outpack/metadata.py
+++ b/src/outpack/metadata.py
@@ -24,15 +24,15 @@ class PacketFile:
 
 
 @dataclass
-class PacketFileWithLocation:
-    path: str
-    size: float
-    hash: str
+class PacketFileWithLocation(PacketFile):
     location: str
+    packet_id: str
 
     @staticmethod
-    def from_packet_file(file: PacketFile, location: str):
-        return PacketFileWithLocation(file.path, file.size, file.hash, location)
+    def from_packet_file(file: PacketFile, location: str, packet_id: str):
+        return PacketFileWithLocation(
+            file.path, file.size, file.hash, location, packet_id
+        )
 
 
 @dataclass_json()

--- a/src/outpack/static.py
+++ b/src/outpack/static.py
@@ -1,4 +1,11 @@
 LOCATION_LOCAL = "local"
 LOCATION_ORPHAN = "orphan"
 LOCATION_RESERVED_NAME = [LOCATION_LOCAL, LOCATION_ORPHAN]
-LOCATION_TYPES = [LOCATION_LOCAL, LOCATION_ORPHAN, "path", "http", "custom"]
+LOCATION_TYPES = [
+    LOCATION_LOCAL,
+    LOCATION_ORPHAN,
+    "path",
+    "http",
+    "custom",
+    "ssh",
+]

--- a/tests/helpers/__init__.py
+++ b/tests/helpers/__init__.py
@@ -19,6 +19,8 @@ from outpack.root import root_open
 from outpack.schema import outpack_schema_version
 from outpack.util import openable_temporary_file
 
+from .ssh_server import SSHServer  # noqa: F401
+
 
 @contextmanager
 def create_packet(root, name, *, packet_id=None, parameters=None):

--- a/tests/helpers/ssh_server.py
+++ b/tests/helpers/ssh_server.py
@@ -1,0 +1,172 @@
+import base64
+import os
+import socket
+import sys
+import threading
+from contextlib import AbstractContextManager, ExitStack
+from pathlib import Path, PurePosixPath
+from typing import List, Optional
+
+import paramiko
+
+
+class SSHServer(AbstractContextManager):
+    """
+    A test SSH server.
+
+    This server should only be used for the purpose of integration testing: it
+    allows connections with any password and exposes an SFTP interface with
+    access to the entire host system.
+
+    All SFTP file accesses begin at the given path, even if the client
+    specifies an absolute path. This is not a security feature (escaping is
+    trivial using ..), but merely simplifies testing, in particular on Windows.
+    The server interprets paths in requests as POSIX like.
+    """
+
+    root: Path
+    port: int
+    host_key: paramiko.PKey
+
+    def __init__(self, root, allowed_users: Optional[List[str]] = None):
+        self.root = root
+        self.allowed_users = allowed_users
+        self.host_key = paramiko.RSAKey.generate(bits=1024)
+        self.shutdown = threading.Event()
+
+    def url(self, path: str, username=None):
+        assert path.startswith("/")
+
+        url = "ssh://"
+        if username is not None:
+            url += f"{username}@"
+        url += f"127.0.0.1:{self.port}{path}"
+        return url
+
+    @property
+    def host_key_entry(self):
+        return (
+            f"[127.0.0.1]:{self.port}",
+            "ssh-rsa",
+            base64.b64encode(self.host_key.asbytes()),
+        )
+
+    def __enter__(self):
+        with ExitStack() as stack:
+            sock = stack.enter_context(
+                socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+            )
+            sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+            sock.bind(("", 0))
+            sock.listen(5)
+
+            (_, self.port) = sock.getsockname()
+
+            t = threading.Thread(target=self._server_loop, args=(sock,))
+            t.start()
+
+            @stack.callback
+            def cleanup():
+                # Setting the shutdown event isn't enough, we also need to wake up
+                # the thread from accept(). Faking a connection is the easiest way.
+                self.shutdown.set()
+                with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+                    s.connect(("127.0.0.1", self.port))
+                t.join()
+
+            self._stack = stack.pop_all()
+            return self
+
+    def __exit__(self, *args):
+        return self._stack.__exit__(*args)
+
+    def _server_loop(self, sock: socket.socket):
+        while True:
+            client, addr = sock.accept()
+            if self.shutdown.is_set():
+                return
+
+            t = paramiko.Transport(client)
+            t.add_server_key(self.host_key)
+            t.set_subsystem_handler(
+                "sftp",
+                paramiko.SFTPServer,
+                SFTPServerInterface,
+                self.root,
+            )
+            t.start_server(
+                event=threading.Event(),
+                server=ServerInterface(self.allowed_users),
+            )
+
+
+class ServerInterface(paramiko.ServerInterface):
+    def __init__(self, allowed_users):
+        self._allowed_users = allowed_users
+
+    def get_allowed_auths(self, _username):
+        return "password"
+
+    def check_auth_password(self, username, _password):
+        if self._allowed_users is None or username in self._allowed_users:
+            return paramiko.common.AUTH_SUCCESSFUL
+        else:
+            return paramiko.common.AUTH_FAILED
+
+    def check_channel_request(self, _kind, _chanid):
+        return paramiko.common.OPEN_SUCCEEDED
+
+
+class SFTPServerInterface(paramiko.SFTPServerInterface):
+    def __init__(self, server, root):
+        super().__init__(server)
+        self.root = root
+
+    def _resolve(self, path: str) -> Path:
+        path = PurePosixPath(path)
+        if path.is_absolute():
+            path = path.relative_to("/")
+        return self.root.joinpath(path)
+
+    def open(self, path, flags, _attr):
+        try:
+            # We only ever do read-only operations on the remote, so at least for
+            # the time being it is easiest to only support that. Otherwise we'd have
+            # the translate flags to the mode string argument of `open`.
+            if flags != os.O_RDONLY:
+                return paramiko.sftp.SFTP_PERMISSION_DENIED
+
+            handle = paramiko.SFTPHandle(flags)
+            handle.readfile = self._resolve(path).open("rb")
+            return handle
+        except OSError as e:
+            return paramiko.SFTPServer.convert_errno(e.errno)
+        except Exception as e:
+            print(e, file=sys.stderr)
+            raise
+
+    def stat(self, path):
+        try:
+            stat = self._resolve(path).stat()
+            return paramiko.SFTPAttributes.from_stat(stat)
+        except OSError as e:
+            return paramiko.SFTPServer.convert_errno(e.errno)
+        except Exception as e:
+            print(e, file=sys.stderr)
+            raise
+
+    def list_folder(self, path):
+        try:
+            result = []
+            path = self._resolve(path)
+            for f in path.iterdir():
+                attrs = paramiko.SFTPAttributes.from_stat(
+                    f.stat(), str(f.relative_to(path))
+                )
+                result.append(attrs)
+            return result
+        except OSError as e:
+            return paramiko.SFTPServer.convert_errno(e.errno)
+        except Exception as e:
+            print(e, file=sys.stderr)
+            raise

--- a/tests/helpers/ssh_server.py
+++ b/tests/helpers/ssh_server.py
@@ -57,6 +57,9 @@ class SSHServer(AbstractContextManager):
                 socket.socket(socket.AF_INET, socket.SOCK_STREAM)
             )
             sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+
+            # Bind to all interfaces on a random port. We read the port back
+            # using getsockname to allow test code to connect.
             sock.bind(("", 0))
             sock.listen(5)
 

--- a/tests/test_location_ssh.py
+++ b/tests/test_location_ssh.py
@@ -1,0 +1,279 @@
+import paramiko
+import pytest
+
+from outpack.hash import hash_file
+from outpack.location import outpack_location_add
+from outpack.location_pull import (
+    outpack_location_pull_metadata,
+    outpack_location_pull_packet,
+)
+from outpack.location_ssh import OutpackLocationSSH, parse_ssh_url
+from outpack.metadata import PacketFile
+from outpack.static import LOCATION_LOCAL
+from outpack.util import read_string
+
+from .helpers import (
+    SSHServer,
+    create_random_packet,
+    create_temporary_root,
+    create_temporary_roots,
+)
+
+
+def server_location(
+    server: SSHServer, path: str, known_hosts=None
+) -> OutpackLocationSSH:
+    if known_hosts is None:
+        known_hosts = [server.host_key_entry]
+
+    return OutpackLocationSSH(
+        url=server.url(path),
+        known_hosts=known_hosts,
+        password="",
+    )
+
+
+def test_can_parse_scp_like_url():
+    assert parse_ssh_url("example.com:foobar") == (
+        None,
+        "example.com",
+        None,
+        "foobar",
+    )
+    assert parse_ssh_url("myuser@example.com:foobar") == (
+        "myuser",
+        "example.com",
+        None,
+        "foobar",
+    )
+    assert parse_ssh_url("myuser@example.com:/home/bob/project") == (
+        "myuser",
+        "example.com",
+        None,
+        "/home/bob/project",
+    )
+
+
+def test_can_parse_explicit_url():
+    assert parse_ssh_url("ssh://example.com/foobar") == (
+        None,
+        "example.com",
+        None,
+        "/foobar",
+    )
+    assert parse_ssh_url("ssh://myuser@example.com/foobar") == (
+        "myuser",
+        "example.com",
+        None,
+        "/foobar",
+    )
+    assert parse_ssh_url("ssh://myuser@example.com:1234/foobar") == (
+        "myuser",
+        "example.com",
+        1234,
+        "/foobar",
+    )
+
+
+def test_errors_on_invalid_url():
+    msg = "Invalid SSH url: 'www.example.com'"
+    with pytest.raises(Exception, match=msg):
+        parse_ssh_url("www.example.com")
+
+    msg = "Invalid SSH url: '/home/alice'"
+    with pytest.raises(Exception, match=msg):
+        parse_ssh_url("/home/alice")
+
+    msg = "Protocol of SSH url must be 'ssh', not 'http'"
+    with pytest.raises(Exception, match=msg):
+        parse_ssh_url("http://www.example.com")
+
+
+def test_errors_on_missing_repo(tmp_path):
+    (tmp_path / "bar").mkdir()
+
+    with SSHServer(tmp_path) as server:
+        msg = "Path '/foo' on remote 127.0.0.1 does not exist"
+        with pytest.raises(Exception, match=msg):
+            with server_location(server, "/foo"):
+                pass
+
+        msg = (
+            "Path '/bar' on remote 127.0.0.1 is not a valid outpack repository"
+        )
+        with pytest.raises(Exception, match=msg):
+            with server_location(server, "/bar"):
+                pass
+
+
+def test_errors_if_host_key_is_unknown(tmp_path):
+    create_temporary_root(tmp_path)
+
+    with SSHServer(tmp_path) as server:
+        msg = "Server .* not found in known_hosts"
+        with pytest.raises(paramiko.SSHException, match=msg):
+            with server_location(server, "/", known_hosts=[]):
+                pass
+
+
+def test_can_read_config(tmp_path):
+    create_temporary_root(tmp_path / "foo", require_complete_tree=True)
+    create_temporary_root(tmp_path / "bar", require_complete_tree=False)
+
+    with SSHServer(tmp_path) as server:
+        with server_location(server, "/foo") as location:
+            assert location.config.core.require_complete_tree
+
+        with server_location(server, "/bar") as location:
+            assert not location.config.core.require_complete_tree
+
+
+def test_can_list_files(tmp_path):
+    root = create_temporary_root(tmp_path)
+    ids = [create_random_packet(tmp_path) for _ in range(3)]
+    packets = root.index.location(LOCATION_LOCAL)
+
+    with SSHServer(tmp_path) as server:
+        with server_location(server, "/") as location:
+            assert set(location.list().keys()) == set(ids)
+            assert location.list() == packets
+
+
+def test_can_fetch_metadata(tmp_path):
+    root = create_temporary_root(tmp_path)
+    ids = [create_random_packet(tmp_path) for _ in range(3)]
+    metadata = {
+        k: read_string(root.path / ".outpack" / "metadata" / k) for k in ids
+    }
+
+    with SSHServer(tmp_path) as server:
+        with server_location(server, "/") as location:
+            assert location.metadata([]) == {}
+            assert location.metadata([ids[0]]) == {ids[0]: metadata[ids[0]]}
+            assert location.metadata(ids) == metadata
+
+
+@pytest.mark.parametrize("use_file_store", [True, False])
+def test_can_fetch_files(tmp_path, use_file_store):
+    root = create_temporary_root(tmp_path, use_file_store=use_file_store)
+    id = create_random_packet(tmp_path)
+    files = root.index.metadata(id).files
+
+    with SSHServer(tmp_path) as server:
+        with server_location(server, "/") as location:
+            dest = tmp_path / "data"
+            location.fetch_file(root.index.metadata(id), files[0], dest)
+            assert str(hash_file(dest)) == files[0].hash
+
+
+@pytest.mark.parametrize("use_file_store", [True, False])
+def test_errors_if_file_not_found(tmp_path, use_file_store):
+    root = create_temporary_root(tmp_path, use_file_store=use_file_store)
+    id = create_random_packet(tmp_path)
+
+    with SSHServer(tmp_path) as server:
+        with server_location(server, "/") as location:
+            packet = root.index.metadata(id)
+            f = PacketFile(
+                path="unknown_data.txt",
+                hash="md5:c7be9a2c3cd8f71210d9097e128da316",
+                size=12,
+            )
+            dest = tmp_path / "dest"
+
+            msg = f"Hash '{f.hash}' not found at location"
+            with pytest.raises(Exception, match=msg):
+                location.fetch_file(packet, f, dest)
+
+
+def test_can_add_ssh_location(tmp_path):
+    root = create_temporary_root(tmp_path)
+    outpack_location_add("upstream1", "ssh", {"url": "example.com:path"}, root)
+    outpack_location_add(
+        "upstream2", "ssh", {"url": "ssh://example.com/path"}, root
+    )
+
+
+def test_cannot_add_invalid_ssh_url(tmp_path):
+    root = create_temporary_root(tmp_path)
+
+    msg = "Protocol of SSH url must be 'ssh', not 'http'"
+    with pytest.raises(Exception, match=msg):
+        outpack_location_add(
+            "upstream", "ssh", {"url": "http://example.com/path"}, root
+        )
+
+
+def test_can_pass_username_in_url(tmp_path):
+    root = create_temporary_roots(tmp_path)
+    with SSHServer(tmp_path, allowed_users=["alice"]) as server:
+        outpack_location_add(
+            "alice_upstream",
+            "ssh",
+            {
+                "url": server.url("/src", username="alice"),
+                "known_hosts": [server.host_key_entry],
+                "password": "",
+            },
+            root=root["dst"],
+        )
+
+        outpack_location_add(
+            "bob_upstream",
+            "ssh",
+            {
+                "url": server.url("/src", username="bob"),
+                "known_hosts": [server.host_key_entry],
+                "password": "",
+            },
+            root=root["dst"],
+        )
+
+        outpack_location_pull_metadata("alice_upstream", root=root["dst"])
+
+        with pytest.raises(paramiko.AuthenticationException):
+            outpack_location_pull_metadata("bob_upstream", root=root["dst"])
+
+
+def test_can_pull_metadata(tmp_path):
+    root = create_temporary_roots(tmp_path)
+    id = create_random_packet(root["src"])
+
+    with SSHServer(tmp_path) as server:
+        url = server.url("/src")
+        outpack_location_add(
+            "upstream",
+            "ssh",
+            {
+                "url": url,
+                "known_hosts": [server.host_key_entry],
+                "password": "",
+            },
+            root=root["dst"],
+        )
+        assert id not in root["dst"].index.all_metadata()
+
+        outpack_location_pull_metadata(root=root["dst"])
+        assert id in root["dst"].index.all_metadata()
+
+
+def test_can_pull_packet(tmp_path):
+    root = create_temporary_roots(tmp_path)
+    id = create_random_packet(root["src"])
+
+    with SSHServer(tmp_path) as server:
+        url = server.url("/src")
+        outpack_location_add(
+            "upstream",
+            "ssh",
+            {
+                "url": url,
+                "known_hosts": [server.host_key_entry],
+                "password": "",
+            },
+            root=root["dst"],
+        )
+        outpack_location_pull_metadata(root=root["dst"])
+        assert id not in root["dst"].index.unpacked()
+        outpack_location_pull_packet(id, root=root["dst"])
+        assert id in root["dst"].index.unpacked()


### PR DESCRIPTION
This is handy when running reports on the Linux cluster and the user wants to pull the results back to their local machine.

The new location supports the same syntaxes as Git uses, either the short SCP-like `username@hostname:path` syntax or the more explicit URL-based `ssh://username@hostname/path`. The latter also allows specifying a port number.

There's a bit of duplicated logic between the core implementation and the new ssh location, since they both deal with the same file layout.  It felt like combining the two would require significant amount of indirections by introducing a VFS that could be implemented both over SFTP and locally, and wasn't worth it since the duplication isn't excessive either.

The location pulling code got refactored a little bit. It used to make many repeated calls to `driver.list()`, but that is inefficient when these calls are over the network. While we could probably cache these calls in the SSH driver, it is easy to just not make them.

The location driver's `fetch_file` interface is changed a little bit to take more metadata in its arguments, including the packet name, id and file path within the packet. This makes it much easier to find the file when the remote location does not have a content-addressed file store.
