### PR TITLE
Return parameter values from the `orderly.parameters` call.

### DIFF
--- a/src/orderly/__init__.py
+++ b/src/orderly/__init__.py
@@ -1,4 +1,5 @@
 from orderly.core import (
+    Parameters,
     artefact,
     dependency,
     description,
@@ -14,4 +15,5 @@ __all__ = [
     "parameters",
     "resource",
     "shared_resource",
+    "Parameters",
 ]

--- a/src/orderly/core.py
+++ b/src/orderly/core.py
@@ -2,6 +2,7 @@ import os.path
 import shutil
 from dataclasses import dataclass
 from pathlib import Path
+from types import SimpleNamespace
 from typing import Dict, List, Union
 
 from dataclasses_json import dataclass_json
@@ -32,7 +33,24 @@ class Description:
         return Description(None, None, None)
 
 
-def parameters(**kwargs):
+class Parameters(SimpleNamespace):
+    """
+    A container for parameters used in a report.
+
+    An instance of this class is returned by the `orderly.parameters` function.
+    Individual parameters can be accessed as fields of the object.
+
+    Example:
+
+        >>> params = orderly.parameters(p=1)
+        >>> params.p
+        1
+    """
+
+    pass
+
+
+def parameters(**kwargs) -> Parameters:
     """Declare parameters used in a report.
 
     Parameters
@@ -50,14 +68,14 @@ def parameters(**kwargs):
     if ctx.is_active:
         # We don't need to apply defaults from kwargs as the packet runner
         # already did so.
-        return ctx.parameters
+        return Parameters(**ctx.parameters)
     else:
         missing = [k for k, v in kwargs.items() if v is None]
         if missing:
             msg = f"No value was specified for {pl(missing, 'parameter')} {', '.join(missing)}."
             raise Exception(msg)
 
-        return kwargs
+        return Parameters(**kwargs)
 
 
 def resource(files):

--- a/src/orderly/current.py
+++ b/src/orderly/current.py
@@ -18,8 +18,6 @@ class OrderlyCustomMetadata:
 
 @dataclass
 class OrderlyContext:
-    # Indicates if a packet is currently running
-    is_active: bool
     # The active packet, if one is running
     packet: Optional[Packet]
     # the path to the packet running directory. This is a pathlib Path object
@@ -32,8 +30,6 @@ class OrderlyContext:
     parameters: dict
     # The name of the packet
     name: str
-    # The id of the packet, only non-None if active
-    id: Optional[str]
     # Special orderly custom metadata
     orderly: OrderlyCustomMetadata
     # Options used when searching for dependencies
@@ -42,14 +38,12 @@ class OrderlyContext:
     @staticmethod
     def from_packet(packet, path_src, search_options=None):
         return OrderlyContext(
-            is_active=True,
             packet=packet,
             path=packet.path,
             path_src=Path(path_src),
             root=packet.root,
             parameters=packet.parameters,
             name=packet.name,
-            id=packet.id,
             orderly=OrderlyCustomMetadata(),
             search_options=search_options,
         )
@@ -58,18 +52,20 @@ class OrderlyContext:
     def interactive():
         path = Path(os.getcwd())
         return OrderlyContext(
-            is_active=False,
             packet=None,
             path=path,
             path_src=path,
             root=detect_orderly_interactive_root(path),
             parameters={},
             name=path.name,
-            id=None,
             orderly=OrderlyCustomMetadata(),
             # TODO: expose a way of configuring this
             search_options=None,
         )
+
+    @property
+    def is_active(self):
+        return self.packet is not None
 
 
 class ActiveOrderlyContext:

--- a/src/orderly/run.py
+++ b/src/orderly/run.py
@@ -72,7 +72,7 @@ def _packet_builder(
 
     try:
         orderly = _run_report_script(
-            packet, path, path_src, entrypoint, parameters, search_options
+            packet, path, path_src, entrypoint, search_options
         )
         _check_artefacts(orderly, path)
     except:
@@ -84,7 +84,7 @@ def _packet_builder(
 
 
 def _run_report_script(
-    packet, path, path_src, entrypoint, parameters, search_options
+    packet, path, path_src, entrypoint, search_options
 ) -> OrderlyCustomMetadata:
     try:
         with ActiveOrderlyContext(packet, path_src, search_options) as orderly:
@@ -92,7 +92,6 @@ def _run_report_script(
             # tracebacks
             runpy.run_path(
                 str(path / entrypoint),
-                init_globals=parameters,
                 run_name="__main__",
             )
 

--- a/tests/orderly/examples/mp/mp.py
+++ b/tests/orderly/examples/mp/mp.py
@@ -12,7 +12,7 @@ if __name__ == "__main__":
     params = orderly.parameters(method=None)
     orderly.artefact("Squared numbers", "result.txt")
 
-    mp = multiprocessing.get_context(params["method"])
+    mp = multiprocessing.get_context(params.method)
     data = [random.random() for _ in range(10)]
 
     with mp.Pool(5) as p:

--- a/tests/orderly/examples/mp/mp.py
+++ b/tests/orderly/examples/mp/mp.py
@@ -3,19 +3,16 @@ import random
 
 import orderly
 
-# TODO(mrc-5255)
-# ruff: noqa: F821
-
 
 def square(x):
     return x * x
 
 
 if __name__ == "__main__":
-    orderly.parameters(method=None)
+    params = orderly.parameters(method=None)
     orderly.artefact("Squared numbers", "result.txt")
 
-    mp = multiprocessing.get_context(method)  # type: ignore
+    mp = multiprocessing.get_context(params["method"])
     data = [random.random() for _ in range(10)]
 
     with mp.Pool(5) as p:

--- a/tests/orderly/examples/parameters/parameters.py
+++ b/tests/orderly/examples/parameters/parameters.py
@@ -1,8 +1,5 @@
 import orderly
 
-# TODO(mrc-5255): We'll rethink this strategy soon
-# ruff: noqa: F821
-
-orderly.parameters(a=1, b=None)
+parameters = orderly.parameters(a=1, b=None)
 with open("result.txt", "w") as f:
-    f.write(f"a: {a}\nb: {b}\n")  # type: ignore
+    f.write(f"a: {parameters['a']}\nb: {parameters['b']}\n")

--- a/tests/orderly/examples/parameters/parameters.py
+++ b/tests/orderly/examples/parameters/parameters.py
@@ -2,4 +2,4 @@ import orderly
 
 parameters = orderly.parameters(a=1, b=None)
 with open("result.txt", "w") as f:
-    f.write(f"a: {parameters['a']}\nb: {parameters['b']}\n")
+    f.write(f"a: {parameters.a}\nb: {parameters.b}\n")

--- a/tests/orderly/test_read.py
+++ b/tests/orderly/test_read.py
@@ -14,6 +14,11 @@ def test_read_simple_trivial_parameters():
     assert ab == {"parameters": {"a": None, "b": 1}}
 
 
+def test_read_parameters_assignment():
+    ab = _read_py("params = orderly.parameters(a=None, b=1)")
+    assert ab == {"parameters": {"a": None, "b": 1}}
+
+
 def test_skip_over_uninteresting_code():
     code = """
 def foo():

--- a/tests/orderly/test_run_metadata.py
+++ b/tests/orderly/test_run_metadata.py
@@ -220,3 +220,35 @@ def test_can_use_dependency_without_packet(tmp_path):
     assert len(result.files) == 1
     assert result.files["input.txt"].path == "result.txt"
     assert src.joinpath("input.txt").exists()
+
+
+def test_can_use_parameters(tmp_path):
+    root = helpers.create_temporary_root(tmp_path)
+    src = tmp_path / "src" / "x"
+    src.mkdir(parents=True)
+
+    p = Packet(root, src, "tmp", parameters={"x": 1, "y": "foo"})
+    with ActiveOrderlyContext(p, src):
+        with transient_working_directory(src):
+            params = orderly.parameters(x=None, y=None)
+            assert params == {"x": 1, "y": "foo"}
+
+
+def test_can_use_parameters_without_packet(tmp_path):
+    helpers.create_temporary_root(tmp_path)
+    src = tmp_path / "src" / "x"
+    src.mkdir(parents=True)
+
+    with transient_working_directory(src):
+        p = orderly.parameters(x=1, y="foo")
+        assert p == {"x": 1, "y": "foo"}
+
+        with pytest.raises(
+            Exception, match="No value was specified for parameter x."
+        ):
+            orderly.parameters(x=None, y="foo")
+
+        with pytest.raises(
+            Exception, match="No value was specified for parameters x, y."
+        ):
+            orderly.parameters(x=None, y=None)

--- a/tests/orderly/test_run_metadata.py
+++ b/tests/orderly/test_run_metadata.py
@@ -231,7 +231,7 @@ def test_can_use_parameters(tmp_path):
     with ActiveOrderlyContext(p, src):
         with transient_working_directory(src):
             params = orderly.parameters(x=None, y=None)
-            assert params == {"x": 1, "y": "foo"}
+            assert params == orderly.Parameters(x=1, y="foo")
 
 
 def test_can_use_parameters_without_packet(tmp_path):
@@ -241,7 +241,7 @@ def test_can_use_parameters_without_packet(tmp_path):
 
     with transient_working_directory(src):
         p = orderly.parameters(x=1, y="foo")
-        assert p == {"x": 1, "y": "foo"}
+        assert p == orderly.Parameters(x=1, y="foo")
 
         with pytest.raises(
             Exception, match="No value was specified for parameter x."


### PR DESCRIPTION
Previously we would inject parameter values as global variables before the script starts executing. While this follows the behaviour of orderly2, it confuses a lot of Python tooling, including linters and type checkers. It also did not support executing orderly scripts outside of a packet context (eg. interactively).

The `orderly.parameters` function now returns the parameter values as a dictionary, which we can get from the global context. When running outside of a packet context, it returns the parameters' default values.