### PR TITLE
 Update outpack schema file.

### DIFF
--- a/src/outpack/schema/outpack/README.md
+++ b/src/outpack/schema/outpack/README.md
@@ -1,8 +1,8 @@
 # Imported from outpack
 
 * Schema version 0.1.1
-* Imported on 2023-12-04 11:53:24.971506
-* From outpack @ 61bd5d84b0c737d3fb7dd24d45e4a117cd4e8bb5 (main)
+* Imported on 2024-05-10 14:22:08.807105
+* From outpack @ 5350c1766d95d1ef707552ed3275ed625a419e0c (main)
 
 Do not make changes to files here, they will be overwritten
 Run ./scripts/update_schemas to update

--- a/src/outpack/schema/outpack/metadata.json
+++ b/src/outpack/schema/outpack/metadata.json
@@ -60,7 +60,7 @@
                 "properties": {
                     "path": {
                         "description": "The path of the file",
-                        "type": "string"
+                        "$ref": "relative-path.json"
                     },
                     "hash": {
                         "$ref": "hash.json"
@@ -93,11 +93,11 @@
                             "properties": {
                                 "here": {
                                     "description": "The path of the file in this packet",
-                                    "type": "string"
+                                    "$ref": "relative-path.json"
                                 },
                                 "there": {
                                     "description": "The path of the file within the upstream packet",
-                                    "type": "string"
+                                    "$ref": "relative-path.json"
                                 }
                             },
                             "required": ["here", "there"]

--- a/src/outpack/schema/outpack/relative-path.json
+++ b/src/outpack/schema/outpack/relative-path.json
@@ -1,0 +1,9 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "File path",
+    "description": "A relative cross-platform file path",
+    "version": "0.1.1",
+
+    "type": "string",
+    "pattern": "^([^<>:\"/\\\\|?*\\x00-\\x1f]+/)*[^<>:\"/\\\\|?*\\x00-\\x1f]+$"
+}


### PR DESCRIPTION
The new schema file adds requirements on the characters used by paths found in the metadata. This aims at ensuring cross-platform compatibility.