### PR TITLE
Make root path absolute when opening.

### DIFF
--- a/src/outpack/root.py
+++ b/src/outpack/root.py
@@ -55,8 +55,10 @@ def root_open(
         return path
 
     if path is None:
-        path = os.getcwd()
-    path = Path(path)
+        path = Path.cwd()
+    else:
+        path = Path(path).absolute()
+
     if not path.is_dir():
         msg = "Expected 'path' to be an existing directory"
         raise Exception(msg)

--- a/tests/orderly/test_run.py
+++ b/tests/orderly/test_run.py
@@ -13,6 +13,7 @@ from outpack.location import outpack_location_add_path
 from outpack.location_pull import outpack_location_pull_metadata
 from outpack.metadata import PacketDepends, PacketDependsPath
 from outpack.search_options import SearchOptions
+from outpack.util import transient_working_directory
 
 from .. import helpers
 
@@ -533,3 +534,13 @@ def test_run_pulls_packet_only_if_require_complete_tree(tmp_path):
 
     assert root["dst1"].index.unpacked() == [id2]
     assert root["dst2"].index.unpacked() == [id1, id3]
+
+
+def test_can_run_with_relative_path_root(tmp_path):
+    root = helpers.create_temporary_root(tmp_path / "foo")
+    helpers.copy_examples("data", root)
+
+    (tmp_path / "bar").mkdir()
+    with transient_working_directory(tmp_path / "bar"):
+        id = orderly_run("data", root="../foo")
+        assert (tmp_path / "foo" / "archive" / "data" / id).exists()

--- a/tests/test_root.py
+++ b/tests/test_root.py
@@ -114,3 +114,16 @@ def test_can_export_files_from_root_using_archive(tmp_path):
     res = r.export_file(id, "data.txt", "result.txt", dest)
     assert res == "result.txt"
     assert (dest / "result.txt").exists()
+
+
+def test_root_path_is_absolute(tmp_path):
+    helpers.create_temporary_root(tmp_path / "foo")
+    (tmp_path / "bar").mkdir()
+
+    with transient_working_directory(tmp_path / "foo"):
+        r = root_open(None)
+        assert r.path.is_absolute()
+
+    with transient_working_directory(tmp_path / "bar"):
+        r = root_open("../foo")
+        assert r.path.is_absolute()


### PR DESCRIPTION
For all user-facing operations that access a root, the user may pass in an explicit location to the root. This path might be relative, in which case it is assumed to be relative to the current working directory.

When running a report, we start a subprocess running inside a new subdirectory of the drafts folder. This makes any existing relative paths that we might pass to the packet builder meaningless in its context, as the current working is now different. Since all these paths are derived from the root path, the it is enough to transform that path at the time when the root is opened.