### PR TITLE
Fix a bug when pulling and filtering at the same time.

### DIFF
--- a/src/outpack/index.py
+++ b/src/outpack/index.py
@@ -46,14 +46,10 @@ class Index:
         return self.refresh().data.location
 
     def location(self, name) -> Dict[str, PacketLocation]:
-        return self.refresh().data.location[name]
+        return self.refresh().data.location.get(name, {})
 
     def packets_in_location(self, name) -> List[str]:
-        try:
-            packets = list(self.location(name).keys())
-        except KeyError:
-            packets = []
-        return packets
+        return list(self.location(name).keys())
 
     def unpacked(self) -> List[str]:
         return self.refresh().data.unpacked

--- a/src/outpack/location.py
+++ b/src/outpack/location.py
@@ -105,6 +105,7 @@ def location_resolve_valid(
             unknown_text = "', '".join(unknown)
             msg = f"Unknown location: '{unknown_text}'"
             raise Exception(msg)
+        location = list(location)
     else:
         msg = (
             "Invalid input for 'location'; expected None or a list of "

--- a/src/outpack/search.py
+++ b/src/outpack/search.py
@@ -6,6 +6,7 @@ from typing import Any, Dict, Optional, Set, Union
 import outpack_query_parser as parser
 
 from outpack.ids import is_outpack_id
+from outpack.location import location_resolve_valid
 from outpack.location_pull import outpack_location_pull_metadata
 from outpack.metadata import MetadataCore, Parameters
 from outpack.root import OutpackRoot, root_open
@@ -61,12 +62,17 @@ class QueryIndex:
     def __init__(self, root, options):
         self.root = root
 
-        locations = root.index.all_locations()
+        locations = location_resolve_valid(
+            options.location,
+            self.root,
+            include_local=True,
+            include_orphan=True,
+            allow_no_locations=False,
+        )
+
         ids = set(
             chain.from_iterable(
-                loc.keys()
-                for name, loc in locations.items()
-                if (options.location is None) or (name in options.location)
+                root.index.location(name).keys() for name in locations
             )
         )
 

--- a/tests/test_location.py
+++ b/tests/test_location.py
@@ -263,3 +263,19 @@ def test_can_resolve_locations(tmp_path):
         )
 
     assert e.match("Unknown location: '[fg]', '[fg]'")
+
+
+def test_resolve_location_makes_copy(tmp_path):
+    root = create_temporary_roots(tmp_path, add_location=True)
+
+    candidates = ["src", "local"]
+    result = location_resolve_valid(
+        candidates,
+        root["dst"],
+        include_local=False,
+        include_orphan=False,
+        allow_no_locations=True,
+    )
+
+    assert result == ["src"]
+    assert candidates == ["src", "local"]


### PR DESCRIPTION
If the search options had both `pull_metadata=True` and a `location` filter set, the local location was excluded from the search regardless of whether it was part of the filter.

This was caused by a call to the `location_resolve_valid` function with `include_local` set to false, which was made as part of pulling the metadata. This call would modify the filter in-place and remove "local" from the list. Later, when the filter was used for the actual search, local was always excluded.

The `location_resolve_valid` function now leaves the argument untouched and instead always returns a copy of it.

Tangentially, the search feature now calls the `location_resolve_valid` function as well, which will catch any unknown locations used in the search options.