### PR TITLE
Remove the support for SCP syntax for ssh locations.

### DIFF
--- a/src/outpack/location_ssh.py
+++ b/src/outpack/location_ssh.py
@@ -47,8 +47,12 @@ def parse_ssh_url(url):
         raise Exception(msg)
 
     path = PurePosixPath(parts.path)
-    if path.is_relative_to("/~"):
-        path = path.relative_to("/~")
+
+    # This condition is equivalent to path.is_relative_to("/~"), except that
+    # function isn't available on Python 3.8.
+    home = PurePosixPath("/~")
+    if path == home or home in path.parents:
+        path = path.relative_to(home)
 
     return parts.username, parts.hostname, parts.port, path
 

--- a/src/outpack/util.py
+++ b/src/outpack/util.py
@@ -217,3 +217,11 @@ def as_posix_path(paths):
         return [as_posix_path(v) for v in paths]
     else:
         return PurePath(paths).as_posix()
+
+
+# Starting with Python 3.9 this exists as a method on str
+def removeprefix(s: str, prefix: str) -> str:
+    if s.startswith(prefix):
+        return s[len(prefix) :]
+    else:
+        return s

--- a/tests/test_location_ssh.py
+++ b/tests/test_location_ssh.py
@@ -1,4 +1,5 @@
-from pathlib import PurePosixPath
+from contextlib import contextmanager
+from pathlib import Path
 
 import paramiko
 import pytest
@@ -22,17 +23,19 @@ from .helpers import (
 )
 
 
-def server_location(
-    server: SSHServer, path: str, known_hosts=None
-) -> OutpackLocationSSH:
-    if known_hosts is None:
-        known_hosts = [server.host_key_entry]
+@contextmanager
+def start_ssh_location(root: Path, path: str = "", known_hosts=None):
+    """Start an SSH server and expose it as an location driver."""
+    with SSHServer(root) as server:
+        if known_hosts is None:
+            known_hosts = [server.host_key_entry]
 
-    return OutpackLocationSSH(
-        url=server.url(path),
-        known_hosts=known_hosts,
-        password="",
-    )
+        with OutpackLocationSSH(
+            url=server.url(path),
+            known_hosts=known_hosts,
+            password="",
+        ) as location:
+            yield location
 
 
 def test_can_parse_url():
@@ -40,41 +43,37 @@ def test_can_parse_url():
         None,
         "example.com",
         None,
-        PurePosixPath("/"),
+        "",
     )
     assert parse_ssh_url("ssh://example.com/foobar") == (
         None,
         "example.com",
         None,
-        PurePosixPath("/foobar"),
+        "foobar",
     )
     assert parse_ssh_url("ssh://myuser@example.com/foobar") == (
         "myuser",
         "example.com",
         None,
-        PurePosixPath("/foobar"),
+        "foobar",
     )
     assert parse_ssh_url("ssh://myuser@example.com:1234/foobar") == (
         "myuser",
         "example.com",
         1234,
-        PurePosixPath("/foobar"),
+        "foobar",
     )
-
-
-def test_can_parse_relative_url():
-    assert parse_ssh_url("ssh://example.com/~") == (
+    assert parse_ssh_url("ssh://example.com//") == (
         None,
         "example.com",
         None,
-        PurePosixPath("."),
+        "/",
     )
-
-    assert parse_ssh_url("ssh://example.com/~/foobar") == (
+    assert parse_ssh_url("ssh://example.com//foo/bar") == (
         None,
         "example.com",
         None,
-        PurePosixPath("foobar"),
+        "/foo/bar",
     )
 
 
@@ -97,40 +96,35 @@ def test_errors_on_invalid_url():
 def test_errors_on_missing_repo(tmp_path):
     (tmp_path / "bar").mkdir()
 
-    with SSHServer(tmp_path) as server:
-        msg = "Path '/foo' on remote 127.0.0.1 does not exist"
-        with pytest.raises(Exception, match=msg):
-            with server_location(server, "/foo"):
-                pass
+    msg = "Path 'foo' on remote 127.0.0.1 does not exist"
+    with pytest.raises(Exception, match=msg):
+        with start_ssh_location(tmp_path, "foo"):
+            pass
 
-        msg = (
-            "Path '/bar' on remote 127.0.0.1 is not a valid outpack repository"
-        )
-        with pytest.raises(Exception, match=msg):
-            with server_location(server, "/bar"):
-                pass
+    msg = "Path 'bar' on remote 127.0.0.1 is not a valid outpack repository"
+    with pytest.raises(Exception, match=msg):
+        with start_ssh_location(tmp_path, "bar"):
+            pass
 
 
 def test_errors_if_host_key_is_unknown(tmp_path):
     create_temporary_root(tmp_path)
 
-    with SSHServer(tmp_path) as server:
-        msg = "Server .* not found in known_hosts"
-        with pytest.raises(paramiko.SSHException, match=msg):
-            with server_location(server, "/", known_hosts=[]):
-                pass
+    msg = "Server .* not found in known_hosts"
+    with pytest.raises(paramiko.SSHException, match=msg):
+        with start_ssh_location(tmp_path, known_hosts=[]):
+            pass
 
 
 def test_can_read_config(tmp_path):
     create_temporary_root(tmp_path / "foo", require_complete_tree=True)
     create_temporary_root(tmp_path / "bar", require_complete_tree=False)
 
-    with SSHServer(tmp_path) as server:
-        with server_location(server, "/foo") as location:
-            assert location.config.core.require_complete_tree
+    with start_ssh_location(tmp_path / "foo") as location:
+        assert location.config.core.require_complete_tree
 
-        with server_location(server, "/bar") as location:
-            assert not location.config.core.require_complete_tree
+    with start_ssh_location(tmp_path / "bar") as location:
+        assert not location.config.core.require_complete_tree
 
 
 def test_can_list_files(tmp_path):
@@ -138,10 +132,9 @@ def test_can_list_files(tmp_path):
     ids = [create_random_packet(tmp_path) for _ in range(3)]
     packets = root.index.location(LOCATION_LOCAL)
 
-    with SSHServer(tmp_path) as server:
-        with server_location(server, "/") as location:
-            assert set(location.list().keys()) == set(ids)
-            assert location.list() == packets
+    with start_ssh_location(tmp_path) as location:
+        assert location.list().keys() == set(ids)
+        assert location.list() == packets
 
 
 def test_can_fetch_metadata(tmp_path):
@@ -151,11 +144,10 @@ def test_can_fetch_metadata(tmp_path):
         k: read_string(root.path / ".outpack" / "metadata" / k) for k in ids
     }
 
-    with SSHServer(tmp_path) as server:
-        with server_location(server, "/") as location:
-            assert location.metadata([]) == {}
-            assert location.metadata([ids[0]]) == {ids[0]: metadata[ids[0]]}
-            assert location.metadata(ids) == metadata
+    with start_ssh_location(tmp_path) as location:
+        assert location.metadata([]) == {}
+        assert location.metadata([ids[0]]) == {ids[0]: metadata[ids[0]]}
+        assert location.metadata(ids) == metadata
 
 
 @pytest.mark.parametrize("use_file_store", [True, False])
@@ -164,11 +156,10 @@ def test_can_fetch_files(tmp_path, use_file_store):
     id = create_random_packet(tmp_path)
     files = root.index.metadata(id).files
 
-    with SSHServer(tmp_path) as server:
-        with server_location(server, "/") as location:
-            dest = tmp_path / "data"
-            location.fetch_file(root.index.metadata(id), files[0], dest)
-            assert str(hash_file(dest)) == files[0].hash
+    with start_ssh_location(tmp_path) as location:
+        dest = tmp_path / "data"
+        location.fetch_file(root.index.metadata(id), files[0], dest)
+        assert str(hash_file(dest)) == files[0].hash
 
 
 @pytest.mark.parametrize("use_file_store", [True, False])
@@ -176,19 +167,18 @@ def test_errors_if_file_not_found(tmp_path, use_file_store):
     root = create_temporary_root(tmp_path, use_file_store=use_file_store)
     id = create_random_packet(tmp_path)
 
-    with SSHServer(tmp_path) as server:
-        with server_location(server, "/") as location:
-            packet = root.index.metadata(id)
-            f = PacketFile(
-                path="unknown_data.txt",
-                hash="md5:c7be9a2c3cd8f71210d9097e128da316",
-                size=12,
-            )
-            dest = tmp_path / "dest"
+    with start_ssh_location(tmp_path) as location:
+        packet = root.index.metadata(id)
+        f = PacketFile(
+            path="unknown_data.txt",
+            hash="md5:c7be9a2c3cd8f71210d9097e128da316",
+            size=12,
+        )
+        dest = tmp_path / "dest"
 
-            msg = f"Hash '{f.hash}' not found at location"
-            with pytest.raises(Exception, match=msg):
-                location.fetch_file(packet, f, dest)
+        msg = f"Hash '{f.hash}' not found at location"
+        with pytest.raises(Exception, match=msg):
+            location.fetch_file(packet, f, dest)
 
 
 def test_can_add_ssh_location(tmp_path):
@@ -215,7 +205,7 @@ def test_can_pass_username_in_url(tmp_path):
             "alice_upstream",
             "ssh",
             {
-                "url": server.url("/src", username="alice"),
+                "url": server.url("src", username="alice"),
                 "known_hosts": [server.host_key_entry],
                 "password": "",
             },
@@ -226,7 +216,7 @@ def test_can_pass_username_in_url(tmp_path):
             "bob_upstream",
             "ssh",
             {
-                "url": server.url("/src", username="bob"),
+                "url": server.url("src", username="bob"),
                 "known_hosts": [server.host_key_entry],
                 "password": "",
             },
@@ -244,7 +234,7 @@ def test_can_pull_metadata(tmp_path):
     id = create_random_packet(root["src"])
 
     with SSHServer(tmp_path) as server:
-        url = server.url("/src")
+        url = server.url("src")
         outpack_location_add(
             "upstream",
             "ssh",
@@ -266,7 +256,7 @@ def test_can_pull_packet(tmp_path):
     id = create_random_packet(root["src"])
 
     with SSHServer(tmp_path) as server:
-        url = server.url("/src")
+        url = server.url("src")
         outpack_location_add(
             "upstream",
             "ssh",
@@ -281,3 +271,16 @@ def test_can_pull_packet(tmp_path):
         assert id not in root["dst"].index.unpacked()
         outpack_location_pull_packet(id, root=root["dst"])
         assert id in root["dst"].index.unpacked()
+
+
+def test_can_use_abolute_path(tmp_path):
+    root = create_temporary_roots(tmp_path, ["foo", "bar"])
+    ids = {k: create_random_packet(v) for k, v in root.items()}
+
+    path = root["foo"].path
+    assert path.is_absolute()
+    with start_ssh_location(tmp_path, path=path.as_posix()) as location:
+        assert location.list().keys() == {ids["foo"]}
+
+    with start_ssh_location(tmp_path, path="bar") as location:
+        assert location.list().keys() == {ids["bar"]}

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -19,6 +19,7 @@ from outpack.util import (
     partition,
     pl,
     read_string,
+    removeprefix,
     time_to_num,
 )
 
@@ -233,3 +234,8 @@ def test_as_posix_path():
         "here/aaa": "there/bbb",
         "foo/bar": "baz/qux",
     }
+
+
+def test_removeprefix():
+    assert removeprefix("foobar", "foo") == "bar"
+    assert removeprefix("foobar", "xxx") == "foobar"


### PR DESCRIPTION
The SCP syntax, of the form `username@hostname:path`, makes inferring the type of location from a URL more difficult. Additionally it introduces two ways of doing the same thing for little benefit.

The only advantage this syntax had (other than conciseness) is that its path was relative by default, whereas the full "ssh://hostname/path" URL syntax always interpreted the path as absolute (following Git's semantics). We now follow the Mercurial semantics, where `ssh://hostname/path` is relative to the user's home directory and `ssh://hostname//path` is absolute.