### PR TITLE
Remove spurious lines in workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -49,7 +49,7 @@ jobs:
           pip install .
           python -c "import orderly; import outpack"
       - name: Upload to Codecov
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v4
         with:
           # This can be useful, but the false positive rate is
           # annoyingly high.

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,9 +8,6 @@ on:
     branches:
       - main
 
-env:
-  CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-
 jobs:
   run:
 
@@ -40,9 +37,6 @@ jobs:
           python -m pip install --upgrade pip
           pip install hatch
       - name: Test
-        env:
-          VAULT_TOKEN: ${{ secrets.VAULT_TOKEN }}
-          YOUTRACK_TOKEN: ${{ secrets.YOUTRACK_TOKEN }}
         run: |
           hatch run cov-ci
       - name: Lint
@@ -60,3 +54,5 @@ jobs:
           # This can be useful, but the false positive rate is
           # annoyingly high.
           fail_ci_if_error: false
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
The vault and youtrack tokens don't exist and aren't used. This is probably a copy-paste from somewhere else.

Also reduce the scope of the codecov token to just the relevant step.