### PR TITLE
Correct the path to the file store.

### DIFF
--- a/src/pyorderly/outpack/location_ssh.py
+++ b/src/pyorderly/outpack/location_ssh.py
@@ -139,6 +139,7 @@ class OutpackLocationSSH(LocationDriver):
             dat = hash_parse(file.hash)
             return (
                 self._root
+                / ".outpack"
                 / "files"
                 / dat.algorithm
                 / dat.value[:2]

--- a/src/pyorderly/outpack/root.py
+++ b/src/pyorderly/outpack/root.py
@@ -20,7 +20,7 @@ class OutpackRoot:
         self.path = Path(path)
         self.config = read_config(path)
         if self.config.core.use_file_store:
-            self.files = FileStore(self.path / "files")
+            self.files = FileStore(self.path / ".outpack" / "files")
         self.index = Index(path)
 
     def export_file(self, id, there, here, dest):


### PR DESCRIPTION
The R and Rust implementations both use `$ROOT/.outpack/files` as the path to the file store. The Python implementation mistakenly used `$ROOT/files` instead, leading to incompatibilities.