### PR TITLE
Add support for pulling from http location. 

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,12 +19,14 @@ jobs:
       fail-fast: false
       matrix:
         config:
-          - {os: macos-latest,   py: '3.11'}
           - {os: ubuntu-latest,  py: '3.8'}
           - {os: ubuntu-latest,  py: '3.9'}
           - {os: ubuntu-latest,  py: '3.10'}
           - {os: ubuntu-latest,  py: '3.11'}
-          - {os: windows-latest, py: '3.11'}
+          - {os: ubuntu-latest,  py: '3.12'}
+          - {os: ubuntu-latest,  py: '3.13'}
+          - {os: macos-latest,   py: '3.13'}
+          - {os: windows-latest, py: '3.13'}
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,6 +37,18 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install hatch
+
+      # Compiling outpack server from source takes a few minutes each time.
+      # This action will cache the result and re-use it on subsequent builds.
+      # The cache is keyed by Git revision, allowing us to pick up new versions
+      # of the server immediately.
+      - name: Install outpack server
+        uses: baptiste0928/cargo-install@v3
+        with:
+          crate: outpack
+          git: https://github.com/mrc-ide/outpack_server
+          features: git2/vendored-libgit2
+
       - name: Test
         run: |
           hatch run cov-ci

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,6 @@ jobs:
       fail-fast: false
       matrix:
         config:
-          - {os: ubuntu-latest,  py: '3.8'}
           - {os: ubuntu-latest,  py: '3.9'}
           - {os: ubuntu-latest,  py: '3.10'}
           - {os: ubuntu-latest,  py: '3.11'}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "pyorderly"
 dynamic = ["version"]
 description = "Reproducible and collaborative reporting"
 readme = "README.md"
-requires-python = ">=3.7"
+requires-python = ">=3.9"
 license = "MIT"
 keywords = []
 authors = [
@@ -16,11 +16,12 @@ authors = [
 classifiers = [
   "Development Status :: 4 - Beta",
   "Programming Language :: Python",
-  "Programming Language :: Python :: 3.7",
   "Programming Language :: Python :: 3.8",
   "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
   "Programming Language :: Python :: Implementation :: CPython",
   "Programming Language :: Python :: Implementation :: PyPy",
 ]
@@ -78,7 +79,7 @@ generate-docs = [
 ]
 
 [[tool.hatch.envs.all.matrix]]
-python = ["3.7", "3.8", "3.9", "3.10", "3.11"]
+python = ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
 
 [tool.hatch.envs.lint]
 extra-dependencies = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ dependencies = [
   "humanize",
   "tblib",
   "paramiko",
+  "requests"
 ]
 
 [project.urls]
@@ -46,15 +47,16 @@ path = "src/pyorderly/__about__.py"
 [tool.hatch.envs.default]
 dependencies = [
   "coverage[toml]>=6.5",
-  "pytest",
-  "pytest_mock",
-  "pytest-unordered",
-  "pytest-cov",
-  "sphinx",
-  "sphinx-rtd-theme",
   "myst-parser",
+  "pytest",
+  "pytest-cov",
+  "pytest-unordered",
+  "pytest_mock",
+  "responses",
+  "sphinx",
+  "sphinx-autoapi",
   "sphinx-copybutton",
-  "sphinx-autoapi"
+  "sphinx-rtd-theme",
 ]
 [tool.hatch.envs.default.scripts]
 test = "pytest {args:tests}"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,8 @@ dependencies = [
   "humanize",
   "tblib",
   "paramiko",
-  "requests"
+  "requests",
+  "typing-extensions",
 ]
 
 [project.urls]

--- a/src/pyorderly/outpack/location.py
+++ b/src/pyorderly/outpack/location.py
@@ -4,6 +4,8 @@ from pathlib import PurePath
 
 from pyorderly.outpack.config import Location, update_config
 from pyorderly.outpack.location_driver import LocationDriver
+from pyorderly.outpack.location_http import OutpackLocationHTTP
+from pyorderly.outpack.location_packit import outpack_location_packit
 from pyorderly.outpack.location_path import OutpackLocationPath
 from pyorderly.outpack.location_ssh import OutpackLocationSSH, parse_ssh_url
 from pyorderly.outpack.root import OutpackRoot, root_open
@@ -34,7 +36,7 @@ def outpack_location_add(name, type, args, root=None, *, locate=True):
         root_open(loc.args["path"], locate=False)
     elif type == "ssh":
         parse_ssh_url(loc.args["url"])
-    elif type in ("http", "custom"):  # pragma: no cover
+    elif type in ("custom",):  # pragma: no cover
         msg = f"Cannot add a location with type '{type}' yet."
         raise Exception(msg)
 
@@ -156,8 +158,11 @@ def _location_driver(location_name, root) -> LocationDriver:
             location.args.get("password"),
         )
     elif location.type == "http":
-        msg = "Http remote not yet supported"
-        raise Exception(msg)
+        return OutpackLocationHTTP(location.args["url"])
+    elif location.type == "packit":
+        return outpack_location_packit(
+            location.args["url"], location.args.get("token")
+        )
     elif location.type == "custom":
         msg = "custom remote not yet supported"
         raise Exception(msg)

--- a/src/pyorderly/outpack/location_http.py
+++ b/src/pyorderly/outpack/location_http.py
@@ -1,0 +1,79 @@
+import shutil
+from typing import Dict, List, override
+from urllib.parse import urljoin
+
+import requests
+
+from pyorderly.outpack.location_driver import LocationDriver
+from pyorderly.outpack.metadata import MetadataCore, PacketFile, PacketLocation
+
+
+def raise_http_error(response: requests.Response):
+    if response.headers.get("Content-Type") == "application/json":
+        result = response.json()
+        # Unfortunately the schema is a bit inconsistent. Packit uses a
+        # singular `error` whereas outpack_server uses a list of
+        # `errors`.
+        if "error" in result:
+            detail = result["error"]["detail"]
+        else:
+            detail = result["errors"][0]["detail"]
+
+        msg = f"{response.status_code} Error: {detail}"
+        raise requests.HTTPError(msg)
+    else:
+        response.raise_for_status()
+
+
+class OutpackHTTPClient(requests.Session):
+    def __init__(self, url: str, authentication=None):
+        super().__init__()
+        self._base_url = url
+        self._authentication = authentication
+
+    @override
+    def request(self, method, path, *args, **kwargs):
+        if self._authentication is not None:
+            headers = kwargs.setdefault("headers", {})
+            headers.update(self._authentication())
+
+        url = urljoin(self._base_url, path)
+        response = super().request(method, url, *args, **kwargs)
+        if not response.ok:
+            raise_http_error(response)
+        return response
+
+
+class OutpackLocationHTTP(LocationDriver):
+    def __init__(self, url: str, authentication=None):
+        self._base_url = url
+        self._client = OutpackHTTPClient(url, authentication)
+
+    def __enter__(self):
+        self._client.__enter__()
+        return self
+
+    def __exit__(self, *args):
+        self._client.__exit__(*args)
+
+    @override
+    def list(self) -> Dict[str, PacketLocation]:
+        response = self._client.get("metadata/list").json()
+        data = response["data"]
+        return {
+            entry["packet"]: PacketLocation.from_dict(entry) for entry in data
+        }
+
+    @override
+    def metadata(self, ids: List[str]) -> Dict[str, str]:
+        result = {}
+        for i in ids:
+            result[i] = self._client.get(f"metadata/{i}/text").text
+
+        return result
+
+    @override
+    def fetch_file(self, packet: MetadataCore, file: PacketFile, dest: str):
+        response = self._client.get(f"file/{file.hash}", stream=True)
+        with open(dest, "wb") as f:
+            shutil.copyfileobj(response.raw, f)

--- a/src/pyorderly/outpack/location_http.py
+++ b/src/pyorderly/outpack/location_http.py
@@ -1,8 +1,9 @@
 import shutil
-from typing import Dict, List, override
+from typing import Dict, List
 from urllib.parse import urljoin
 
 import requests
+from typing_extensions import override
 
 from pyorderly.outpack.location_driver import LocationDriver
 from pyorderly.outpack.metadata import MetadataCore, PacketFile, PacketLocation

--- a/src/pyorderly/outpack/location_packit.py
+++ b/src/pyorderly/outpack/location_packit.py
@@ -131,7 +131,7 @@ class OAuthDeviceClient:
         parameters: DeviceAuthorizationResponse,
     ) -> AccessTokenResponse:
         interval = parameters.interval
-        if parameters.interval is None:
+        if parameters.interval is None:  # pragma: no cover
             interval = 5
         else:
             interval = parameters.interval
@@ -142,7 +142,7 @@ class OAuthDeviceClient:
                 return response
             elif response.error == "authorization_pending":
                 pass
-            elif response.error == "slow_down":
+            elif response.error == "slow_down":  # pragma: no cover
                 interval += 5
             else:
                 if response.error_description is not None:

--- a/src/pyorderly/outpack/location_packit.py
+++ b/src/pyorderly/outpack/location_packit.py
@@ -185,7 +185,7 @@ def packit_authorisation(url: str, token: Optional[str]) -> Dict[str, str]:
     response = client.post("packit/api/auth/login/api", json={"token": token})
 
     print("Logged in successfully")
-    return {"Authorization": f"Bearer {response.json()["token"]}"}
+    return {"Authorization": f"Bearer {response.json()['token']}"}
 
 
 def outpack_location_packit(

--- a/src/pyorderly/outpack/location_packit.py
+++ b/src/pyorderly/outpack/location_packit.py
@@ -1,0 +1,200 @@
+import functools
+import re
+import time
+from dataclasses import dataclass
+from typing import Dict, Optional, Union
+from urllib.parse import urljoin
+
+import requests
+from dataclasses_json import DataClassJsonMixin, dataclass_json
+
+from pyorderly.outpack.location_http import (
+    OutpackHTTPClient,
+    OutpackLocationHTTP,
+)
+
+# Surprisingly, we don't actually need the Client ID here to match the one
+# used by Packit. It should be fine to hardcode a value regardless of which
+# server we are talking to.
+GITHUB_CLIENT_ID = "Ov23liUrbkR0qUtAO1zu"
+
+GITHUB_DEVICE_CODE_URL = "https://github.com/login/device/code"
+GITHUB_ACCESS_TOKEN_URL = "https://github.com/login/oauth/access_token"
+
+
+@dataclass
+class DeviceAuthorizationResponse(DataClassJsonMixin):
+    device_code: str
+    user_code: str
+    verification_uri: str
+    expires_in: int
+    interval: Optional[int] = None
+
+
+@dataclass
+class AccessTokenResponse(DataClassJsonMixin):
+    access_token: str
+    token_type: str
+    expires_in: Optional[int] = None
+
+
+@dataclass_json
+@dataclass
+class ErrorResponse(DataClassJsonMixin):
+    error: str
+    error_description: Optional[str] = None
+
+
+class OAuthDeviceClient:
+    def __init__(
+        self,
+        client_id: str,
+        device_code_url: str,
+        access_token_url: str,
+    ):
+        self._client_id = client_id
+        self._device_code_url = device_code_url
+        self._access_token_url = access_token_url
+        self._session = requests.Session()
+
+    def __enter__(self):
+        self._session.__enter__()
+        return self
+
+    def __exit__(self, *args):
+        self._session.__exit__(*args)
+
+    def authenticate(self, scope: str) -> AccessTokenResponse:
+        parameters = self.start_device_authorization(scope)
+        print(
+            f"Visit {parameters.verification_uri} and enter the code <{parameters.user_code}>"
+        )
+        print(parameters)
+        response = self.poll_access_token(parameters)
+        return response
+
+    def start_device_authorization(
+        self, scope: str
+    ) -> DeviceAuthorizationResponse:
+        """
+        Initiate the device authorization flow.
+
+        This function returns a user code and verification URI which should be
+        presented to the user. Additionally, it returns a device code which may
+        be used to poll the access token endpoint until the authentication flow
+        is complete.
+
+        https://datatracker.ietf.org/doc/html/rfc8628#section-3.1
+        https://datatracker.ietf.org/doc/html/rfc8628#section-3.2
+        """
+        r = self._session.post(
+            self._device_code_url,
+            data={"client_id": self._client_id, "scope": scope},
+            headers={"Accept": "application/json"},
+        )
+        r.raise_for_status()
+        return DeviceAuthorizationResponse.from_dict(r.json())
+
+    def fetch_access_token(
+        self, parameters: DeviceAuthorizationResponse
+    ) -> Union[AccessTokenResponse, ErrorResponse]:
+        """
+        Fetch an access token from the authentication server.
+
+        If authentication succeeds, an AccessTokenResponse is returned.
+        Otherwise an ErrorResponse is returned. Depending on the error's code,
+        the caller may call this function again (after a delay) to poll for new
+        tokens.
+
+        https://datatracker.ietf.org/doc/html/rfc8628#section-3.4
+        https://datatracker.ietf.org/doc/html/rfc8628#section-3.5
+        """
+        r = self._session.post(
+            self._access_token_url,
+            data={
+                "grant_type": "urn:ietf:params:oauth:grant-type:device_code",
+                "device_code": parameters.device_code,
+                "client_id": self._client_id,
+            },
+            headers={"Accept": "application/json"},
+        )
+
+        data = r.json()
+
+        if "error" in data:
+            return ErrorResponse.from_dict(r.json())
+        else:
+            r.raise_for_status()
+            return AccessTokenResponse.from_dict(r.json())
+
+    def poll_access_token(
+        self,
+        parameters: DeviceAuthorizationResponse,
+    ) -> AccessTokenResponse:
+        interval = parameters.interval
+        if parameters.interval is None:
+            interval = 5
+        else:
+            interval = parameters.interval
+
+        while True:
+            response = self.fetch_access_token(parameters)
+            if isinstance(response, AccessTokenResponse):
+                return response
+            elif response.error == "authorization_pending":
+                pass
+            elif response.error == "slow_down":
+                interval += 5
+            else:
+                if response.error_description is not None:
+                    msg = f"Error while fetching access token: {response.error_description} ({response.error})"
+                else:
+                    msg = f"Error while fetching access token: {response.error}"
+                raise Exception(msg)
+
+            time.sleep(interval)
+
+
+# The `functools.cache` decorator provides a very crude in-memory cache.
+#
+# If no token is provided we don't want to make the user have to authenticate
+# interactively repeatedly; Even if a GitHub PAT is provided, trading it for a
+# Packit token is slow and we wouldn't want to do it needlessly.
+#
+# This cache could be improved:
+# - It should cache the tokens on disk (if the user requests it)
+# - It should check for expiry of tokens and/or check for authentication errors
+#   and purge offending tokens from it.
+@functools.cache
+def packit_authorisation(url: str, token: Optional[str]) -> Dict[str, str]:
+    # If a non-Github token is provided, we assume it is a native Packit token
+    # and use that directly.
+    if token is not None and not re.match("^gh._", token):
+        return {"Authorization": f"Bearer {token}"}
+
+    print(f"Logging in to {url}")
+    if token is None:
+        with OAuthDeviceClient(
+            GITHUB_CLIENT_ID,
+            GITHUB_DEVICE_CODE_URL,
+            GITHUB_ACCESS_TOKEN_URL,
+        ) as client:
+            token = client.authenticate("read:org").access_token
+
+    client = OutpackHTTPClient(url)
+    response = client.post("packit/api/auth/login/api", json={"token": token})
+
+    print("Logged in successfully")
+    return {"Authorization": f"Bearer {response.json()["token"]}"}
+
+
+def outpack_location_packit(
+    url: str, token: Optional[str] = None
+) -> OutpackLocationHTTP:
+    if not url.endswith("/"):
+        url += "/"
+
+    return OutpackLocationHTTP(
+        urljoin(url, "packit/api/outpack/"),
+        lambda: packit_authorisation(url, token),
+    )

--- a/src/pyorderly/outpack/location_packit.py
+++ b/src/pyorderly/outpack/location_packit.py
@@ -69,7 +69,6 @@ class OAuthDeviceClient:
         print(
             f"Visit {parameters.verification_uri} and enter the code <{parameters.user_code}>"
         )
-        print(parameters)
         response = self.poll_access_token(parameters)
         return response
 

--- a/src/pyorderly/outpack/location_path.py
+++ b/src/pyorderly/outpack/location_path.py
@@ -2,6 +2,8 @@ import os
 import shutil
 from typing import Dict, List
 
+from typing_extensions import override
+
 from pyorderly.outpack.location_driver import LocationDriver
 from pyorderly.outpack.metadata import MetadataCore, PacketFile, PacketLocation
 from pyorderly.outpack.root import find_file_by_hash, root_open
@@ -13,15 +15,19 @@ class OutpackLocationPath(LocationDriver):
     def __init__(self, path):
         self.__root = root_open(path, locate=False)
 
+    @override
     def __enter__(self):
         return self
 
+    @override
     def __exit__(self, exc_type, exc_value, exc_tb):
         pass
 
+    @override
     def list(self) -> Dict[str, PacketLocation]:
         return self.__root.index.location(LOCATION_LOCAL)
 
+    @override
     def metadata(self, packet_ids: List[str]) -> Dict[str, str]:
         all_ids = self.__root.index.location(LOCATION_LOCAL).keys()
         missing_ids = set(packet_ids).difference(all_ids)
@@ -35,6 +41,7 @@ class OutpackLocationPath(LocationDriver):
             ret[packet_id] = read_string(path)
         return ret
 
+    @override
     def fetch_file(self, _packet: MetadataCore, file: PacketFile, dest: str):
         if self.__root.config.core.use_file_store:
             path = self.__root.files.filename(file.hash)

--- a/src/pyorderly/outpack/location_ssh.py
+++ b/src/pyorderly/outpack/location_ssh.py
@@ -6,6 +6,7 @@ from typing import Dict, List
 from urllib.parse import urlsplit
 
 import paramiko
+from typing_extensions import override
 
 from pyorderly.outpack.config import Config
 from pyorderly.outpack.hash import hash_parse
@@ -52,6 +53,7 @@ class OutpackLocationSSH(LocationDriver):
         self._password = password
         self._stack = ExitStack()
 
+    @override
     def __enter__(self):
         with ExitStack() as stack:
             client = stack.enter_context(paramiko.SSHClient())
@@ -98,9 +100,11 @@ class OutpackLocationSSH(LocationDriver):
 
             return self
 
+    @override
     def __exit__(self, *args):
         return self._stack.__exit__(*args)
 
+    @override
     def list(self) -> Dict[str, PacketLocation]:
         path = self._root / ".outpack" / "location" / LOCATION_LOCAL
         result = {}
@@ -109,6 +113,7 @@ class OutpackLocationSSH(LocationDriver):
                 result[packet] = PacketLocation.from_json(f.read().strip())
         return result
 
+    @override
     def metadata(self, ids: List[str]) -> Dict[str, str]:
         path = self._root / ".outpack" / "metadata"
         result = {}
@@ -119,6 +124,7 @@ class OutpackLocationSSH(LocationDriver):
 
         return result
 
+    @override
     def fetch_file(self, packet: MetadataCore, file: PacketFile, dest: str):
         path = self._file_path(packet, file)
         if path is None:

--- a/src/pyorderly/outpack/location_ssh.py
+++ b/src/pyorderly/outpack/location_ssh.py
@@ -13,7 +13,6 @@ from pyorderly.outpack.hash import hash_parse
 from pyorderly.outpack.location_driver import LocationDriver
 from pyorderly.outpack.metadata import MetadataCore, PacketFile, PacketLocation
 from pyorderly.outpack.static import LOCATION_LOCAL
-from pyorderly.outpack.util import removeprefix
 
 
 def parse_ssh_url(url):
@@ -35,7 +34,7 @@ def parse_ssh_url(url):
         msg = "No path specified for SSH location"
         raise Exception(msg)
 
-    path = removeprefix(parts.path, "/")
+    path = parts.path.removeprefix("/")
     return parts.username, parts.hostname, parts.port, path
 
 

--- a/src/pyorderly/outpack/static.py
+++ b/src/pyorderly/outpack/static.py
@@ -6,6 +6,7 @@ LOCATION_TYPES = [
     LOCATION_ORPHAN,
     "path",
     "http",
+    "packit",
     "custom",
     "ssh",
 ]

--- a/src/pyorderly/outpack/util.py
+++ b/src/pyorderly/outpack/util.py
@@ -217,11 +217,3 @@ def as_posix_path(paths):
         return [as_posix_path(v) for v in paths]
     else:
         return PurePath(paths).as_posix()
-
-
-# Starting with Python 3.9 this exists as a method on str
-def removeprefix(s: str, prefix: str) -> str:
-    if s.startswith(prefix):
-        return s[len(prefix) :]
-    else:
-        return s

--- a/tests/helpers/outpack_server.py
+++ b/tests/helpers/outpack_server.py
@@ -48,9 +48,7 @@ def _wait_ready(p, url, args, timeout=2):
             raise subprocess.CalledProcessError(code, args)
 
         try:
-            print(url)
             r = requests.get(url, timeout=1)
-            print(r)
             r.raise_for_status()
             return
         except requests.ConnectionError:

--- a/tests/helpers/outpack_server.py
+++ b/tests/helpers/outpack_server.py
@@ -72,7 +72,7 @@ def start_outpack_server(root: Union[Path, OutpackRoot], port: int = 8080):
         root_path = str(root)
 
     args = [
-        "outpack",
+        binary,
         "start-server",
         "--root",
         root_path,

--- a/tests/helpers/outpack_server.py
+++ b/tests/helpers/outpack_server.py
@@ -1,0 +1,95 @@
+import shutil
+import signal
+import subprocess
+import time
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Union
+
+import pytest
+import requests
+
+from pyorderly.outpack.root import OutpackRoot
+
+
+def _wait_ready(p, url, args, timeout=2):
+    # This function waits for outpack server to become ready while monitoring
+    # the child process to detect any start-up errors.
+    #
+    # In a modern (post-2019) Linux world, the foolproof way to do this is as
+    # follows:
+    # - Setup a lightweight IPC between us and the server used to communicate
+    #   readiness. This can be an sd_notify socket, an eventfd or just a pipe.
+    # - Setup a pidfd that can be used to watch the child
+    #   process.
+    # - Use select(2) to wait for the two events simultaneously.
+    #
+    # The IPC can probably be designed to be portable, albeit not using the
+    # sd_notify protocol. Other platforms have equivalents to the pidfd and
+    # select combo (namely kqueue on macOS, or WaitForMultipleObjects on
+    # Windows), but these are all very-platform specific and don't have
+    # bindings in the Python stdlib.
+    #
+    # asyncio should provide a platform-independent way to do this kind of
+    # stuff, but it's a lot of boilerplate and the asyncio module don't have a
+    # way to monitor an existing child process. It's not obvious what would
+    # happend if we launched the child process using the asyncio module and
+    # then shut down the event loop once the server is ready.
+    #
+    # In the end, we do the low-tech thing and poll the HTTP endpoint until it
+    # becomes ready. Each time that fails, we also check the process to see if
+    # it has quit. It can add a bit of latency due to the sleep in the polling
+    # loop, but it is more portable and simpler than any other solution.
+
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        code = p.poll()
+        if code is not None:
+            raise subprocess.CalledProcessError(code, args)
+
+        try:
+            print(url)
+            r = requests.get(url, timeout=1)
+            print(r)
+            r.raise_for_status()
+            return
+        except requests.ConnectionError:
+            pass
+
+        time.sleep(0.05)
+
+    msg = "outpack_server failed to start in time"
+    raise Exception(msg)
+
+
+@contextmanager
+def start_outpack_server(root: Union[Path, OutpackRoot], port: int = 8080):
+    binary = shutil.which("outpack")
+    if binary is None:
+        pytest.skip("outpack_server not installed")
+
+    if isinstance(root, OutpackRoot):
+        root_path = str(root.path)
+    else:
+        root_path = str(root)
+
+    args = [
+        "outpack",
+        "start-server",
+        "--root",
+        root_path,
+        "--listen",
+        f"0.0.0.0:{port}",
+    ]
+
+    url = f"http://127.0.0.1:{port}"
+    with subprocess.Popen(args) as p:  # noqa: S603
+        try:
+            _wait_ready(p, url, args)
+            yield url
+        finally:
+            p.terminate()
+
+    expected_code = -signal.SIGTERM
+    if p.returncode != expected_code:
+        raise subprocess.CalledProcessError(p.returncode, args)

--- a/tests/outpack/test_location.py
+++ b/tests/outpack/test_location.py
@@ -170,13 +170,6 @@ def test_cant_add_wip_location_type(tmp_path):
 
     with pytest.raises(Exception) as e:
         outpack_location_add(
-            "other", "http", {"url": "https://example.com"}, root=root
-        )
-
-    assert e.match("Cannot add a location with type 'http' yet.")
-
-    with pytest.raises(Exception) as e:
-        outpack_location_add(
             "other", "custom", {"driver": "mydriver"}, root=root
         )
 

--- a/tests/outpack/test_location_http.py
+++ b/tests/outpack/test_location_http.py
@@ -1,0 +1,167 @@
+from typing import Dict
+
+import pytest
+import requests
+
+from pyorderly.outpack.hash import hash_file
+from pyorderly.outpack.location import outpack_location_add
+from pyorderly.outpack.location_http import OutpackLocationHTTP
+from pyorderly.outpack.location_pull import (
+    outpack_location_pull_metadata,
+    outpack_location_pull_packet,
+)
+from pyorderly.outpack.metadata import PacketFile, PacketLocation
+from pyorderly.outpack.static import LOCATION_LOCAL
+from pyorderly.outpack.util import read_string
+
+from ..helpers import (
+    create_random_packet,
+    create_temporary_root,
+    create_temporary_roots,
+)
+from ..helpers.outpack_server import start_outpack_server
+
+
+def test_can_list_packets(tmp_path):
+    root = create_temporary_root(
+        tmp_path,
+        use_file_store=True,
+        require_complete_tree=True,
+        path_archive=None,
+    )
+    ids = [create_random_packet(tmp_path) for _ in range(3)]
+    packets = root.index.location(LOCATION_LOCAL)
+
+    def filter_out_time(data: Dict[str, PacketLocation]) -> Dict[str, dict]:
+        # outpack_server doesn't roundtrip the floating-point time field very
+        # well, which leads to flaky tests.
+        return {
+            id: {k: v for k, v in entry.to_dict().items() if k != "time"}
+            for id, entry in data.items()
+        }
+
+    with start_outpack_server(tmp_path) as url:
+        location = OutpackLocationHTTP(url)
+        assert location.list().keys() == set(ids)
+        assert filter_out_time(location.list()) == filter_out_time(packets)
+
+
+def test_can_fetch_metadata(tmp_path):
+    root = create_temporary_root(
+        tmp_path,
+        use_file_store=True,
+        require_complete_tree=True,
+        path_archive=None,
+    )
+    ids = [create_random_packet(tmp_path) for _ in range(3)]
+    metadata = {
+        k: read_string(root.path / ".outpack" / "metadata" / k) for k in ids
+    }
+
+    with start_outpack_server(tmp_path) as url:
+        location = OutpackLocationHTTP(url)
+        assert location.metadata([]) == {}
+        assert location.metadata([ids[0]]) == {ids[0]: metadata[ids[0]]}
+        assert location.metadata(ids) == metadata
+
+
+def test_can_fetch_files(tmp_path_factory):
+    root = create_temporary_root(
+        tmp_path_factory.mktemp("server"),
+        use_file_store=True,
+        require_complete_tree=True,
+        path_archive=None,
+    )
+    id = create_random_packet(root)
+    files = root.index.metadata(id).files
+
+    dest = tmp_path_factory.mktemp("data") / "result"
+
+    with start_outpack_server(root) as url:
+        location = OutpackLocationHTTP(url)
+
+        location.fetch_file(root.index.metadata(id), files[0], dest)
+
+        assert str(hash_file(dest)) == files[0].hash
+
+
+def test_errors_if_file_not_found(tmp_path_factory):
+    root = create_temporary_root(
+        tmp_path_factory.mktemp("server"),
+        use_file_store=True,
+        require_complete_tree=True,
+        path_archive=None,
+    )
+    id = create_random_packet(root)
+
+    dest = tmp_path_factory.mktemp("data") / "result"
+
+    with start_outpack_server(root) as url:
+        location = OutpackLocationHTTP(url)
+        packet = root.index.metadata(id)
+        f = PacketFile(
+            path="unknown_data.txt",
+            hash="md5:c7be9a2c3cd8f71210d9097e128da316",
+            size=12,
+        )
+
+        msg = f"'{f.hash}' not found"
+        with pytest.raises(requests.HTTPError, match=msg):
+            location.fetch_file(packet, f, dest)
+
+
+def test_can_add_http_location(tmp_path):
+    root = create_temporary_root(
+        tmp_path,
+        use_file_store=True,
+        require_complete_tree=True,
+        path_archive=None,
+    )
+    outpack_location_add(
+        "upstream", "http", {"url": "http://example.com/path"}, root
+    )
+
+
+def test_can_pull_metadata(tmp_path):
+    root = create_temporary_roots(
+        tmp_path,
+        use_file_store=True,
+        require_complete_tree=True,
+        path_archive=None,
+    )
+    id = create_random_packet(root["src"])
+
+    with start_outpack_server(root["src"]) as url:
+        outpack_location_add(
+            "upstream",
+            "http",
+            {"url": url},
+            root=root["dst"],
+        )
+        assert id not in root["dst"].index.all_metadata()
+
+        outpack_location_pull_metadata(root=root["dst"])
+        assert id in root["dst"].index.all_metadata()
+
+
+def test_can_pull_packet(tmp_path):
+    root = create_temporary_roots(
+        tmp_path,
+        use_file_store=True,
+        require_complete_tree=True,
+        path_archive=None,
+    )
+    id = create_random_packet(root["src"])
+
+    with start_outpack_server(root["src"]) as url:
+        outpack_location_add(
+            "upstream",
+            "http",
+            {"url": url},
+            root=root["dst"],
+        )
+
+        outpack_location_pull_metadata(root=root["dst"])
+        assert id not in root["dst"].index.unpacked()
+        outpack_location_pull_packet(id, root=root["dst"])
+        assert id in root["dst"].index.unpacked()

--- a/tests/outpack/test_location_packit.py
+++ b/tests/outpack/test_location_packit.py
@@ -1,10 +1,10 @@
-import pytest
 import re
+
+import pytest
 import responses
 from responses import matchers
 from responses.registries import OrderedRegistry
 
-from pyorderly.outpack.location_pull import outpack_location_pull_metadata
 from pyorderly.outpack.location import outpack_location_add
 from pyorderly.outpack.location_packit import (
     GITHUB_ACCESS_TOKEN_URL,
@@ -14,6 +14,7 @@ from pyorderly.outpack.location_packit import (
     outpack_location_packit,
     packit_authorisation,
 )
+from pyorderly.outpack.location_pull import outpack_location_pull_metadata
 
 from ..helpers import create_temporary_root
 

--- a/tests/outpack/test_location_packit.py
+++ b/tests/outpack/test_location_packit.py
@@ -1,0 +1,160 @@
+import pytest
+import responses
+from responses import matchers
+from responses.registries import OrderedRegistry
+
+from pyorderly.outpack.location_packit import (
+    GITHUB_ACCESS_TOKEN_URL,
+    GITHUB_CLIENT_ID,
+    GITHUB_DEVICE_CODE_URL,
+    outpack_location_packit,
+    packit_authorisation,
+)
+
+
+# This fixture automatically gets invoked by all tests in the file, and will
+# clear the authorisation cache to avoid carrying tokens over.
+@pytest.fixture(autouse=True)
+def clear_authentication_cache():
+    try:
+        yield
+    finally:
+        packit_authorisation.cache_clear()
+
+
+@responses.activate(assert_all_requests_are_fired=True)
+def test_can_pass_packit_token():
+    responses.get(
+        "https://example.com/packit/api/outpack/metadata/list",
+        json={"status": "success", "data": []},
+        match=[matchers.header_matcher({"Authorization": "Bearer mytoken"})],
+    )
+
+    location = outpack_location_packit("https://example.com", token="mytoken")
+    location.list()
+
+
+@responses.activate(assert_all_requests_are_fired=True)
+def test_can_pass_github_personal_token():
+    responses.post(
+        "https://example.com/packit/api/auth/login/api",
+        match=[matchers.json_params_matcher({"token": "ghp_token"})],
+        json={"token": "mytoken"},
+    )
+    responses.get(
+        "https://example.com/packit/api/outpack/metadata/list",
+        match=[matchers.header_matcher({"Authorization": "Bearer mytoken"})],
+        json={"status": "success", "data": []},
+    )
+
+    location = outpack_location_packit("https://example.com", token="ghp_token")
+    location.list()
+
+
+@responses.activate(assert_all_requests_are_fired=True)
+def test_authentication_is_cached():
+    auth_response = responses.post(
+        "https://example.com/packit/api/auth/login/api",
+        match=[matchers.json_params_matcher({"token": "ghp_token"})],
+        json={"token": "mytoken"},
+    )
+    list_response = responses.get(
+        "https://example.com/packit/api/outpack/metadata/list",
+        match=[matchers.header_matcher({"Authorization": "Bearer mytoken"})],
+        json={"status": "success", "data": []},
+    )
+
+    location = outpack_location_packit("https://example.com", token="ghp_token")
+    location.list()
+
+    assert auth_response.call_count == 1
+    assert list_response.call_count == 1
+
+    location.list()
+
+    assert auth_response.call_count == 1
+    assert list_response.call_count == 2
+
+
+@responses.activate(
+    registry=OrderedRegistry, assert_all_requests_are_fired=True
+)
+def test_can_perform_interactive_authentication(capsys):
+    responses.post(
+        GITHUB_DEVICE_CODE_URL,
+        json={
+            "device_code": "xxxxx",
+            "user_code": "1234-5678",
+            "verification_uri": "https://github.com/login/device",
+            "expires_in": 3600,
+            "interval": 0,
+        },
+        match=[
+            matchers.urlencoded_params_matcher(
+                {
+                    "client_id": GITHUB_CLIENT_ID,
+                    "scope": "read:org",
+                }
+            )
+        ],
+    )
+
+    m = matchers.urlencoded_params_matcher(
+        {
+            "grant_type": "urn:ietf:params:oauth:grant-type:device_code",
+            "device_code": "xxxxx",
+            "client_id": GITHUB_CLIENT_ID,
+        }
+    )
+
+    responses.post(
+        GITHUB_ACCESS_TOKEN_URL,
+        json={"error": "authorization_pending"},
+        match=[m],
+    )
+
+    responses.post(
+        GITHUB_ACCESS_TOKEN_URL,
+        json={"access_token": "ghp_token", "token_type": "bearer"},
+        match=[m],
+    )
+
+    responses.post(
+        "https://example.com/packit/api/auth/login/api",
+        match=[matchers.json_params_matcher({"token": "ghp_token"})],
+        json={"token": "mytoken"},
+    )
+
+    responses.get(
+        "https://example.com/packit/api/outpack/metadata/list",
+        match=[matchers.header_matcher({"Authorization": "Bearer mytoken"})],
+        json={"status": "success", "data": []},
+    )
+
+    location = outpack_location_packit("https://example.com")
+    location.list()
+
+    captured = capsys.readouterr()
+    assert "enter the code <1234-5678>" in captured.out
+
+
+@responses.activate(assert_all_requests_are_fired=True)
+def test_failed_authentication():
+    responses.post(
+        GITHUB_DEVICE_CODE_URL,
+        json={
+            "device_code": "xxxxx",
+            "user_code": "1234-5678",
+            "verification_uri": "https://github.com/login/device",
+            "expires_in": 3600,
+            "interval": 0,
+        },
+    )
+
+    responses.post(GITHUB_ACCESS_TOKEN_URL, json={"error": "access_denied"})
+
+    location = outpack_location_packit("https://example.com")
+
+    msg = "Error while fetching access token: access_denied"
+    with pytest.raises(Exception, match=msg):
+        location.list()

--- a/tests/outpack/test_location_packit.py
+++ b/tests/outpack/test_location_packit.py
@@ -1,15 +1,21 @@
 import pytest
+import re
 import responses
 from responses import matchers
 from responses.registries import OrderedRegistry
 
+from pyorderly.outpack.location_pull import outpack_location_pull_metadata
+from pyorderly.outpack.location import outpack_location_add
 from pyorderly.outpack.location_packit import (
     GITHUB_ACCESS_TOKEN_URL,
     GITHUB_CLIENT_ID,
     GITHUB_DEVICE_CODE_URL,
+    OAuthDeviceClient,
     outpack_location_packit,
     packit_authorisation,
 )
+
+from ..helpers import create_temporary_root
 
 
 # This fixture automatically gets invoked by all tests in the file, and will
@@ -139,7 +145,7 @@ def test_can_perform_interactive_authentication(capsys):
 
 
 @responses.activate(assert_all_requests_are_fired=True)
-def test_failed_authentication():
+def test_oauth_failed_authentication():
     responses.post(
         GITHUB_DEVICE_CODE_URL,
         json={
@@ -153,8 +159,60 @@ def test_failed_authentication():
 
     responses.post(GITHUB_ACCESS_TOKEN_URL, json={"error": "access_denied"})
 
-    location = outpack_location_packit("https://example.com")
+    with OAuthDeviceClient(
+        GITHUB_CLIENT_ID,
+        GITHUB_DEVICE_CODE_URL,
+        GITHUB_ACCESS_TOKEN_URL,
+    ) as client:
+        msg = "Error while fetching access token: access_denied"
+        with pytest.raises(Exception, match=msg):
+            client.authenticate("read:org")
 
-    msg = "Error while fetching access token: access_denied"
-    with pytest.raises(Exception, match=msg):
-        location.list()
+
+@responses.activate(assert_all_requests_are_fired=True)
+def test_oauth_failed_authentication_with_description():
+    responses.post(
+        GITHUB_DEVICE_CODE_URL,
+        json={
+            "device_code": "xxxxx",
+            "user_code": "1234-5678",
+            "verification_uri": "https://github.com/login/device",
+            "expires_in": 3600,
+            "interval": 0,
+        },
+    )
+
+    responses.post(
+        GITHUB_ACCESS_TOKEN_URL,
+        json={
+            "error": "access_denied",
+            "error_description": "Access was denied",
+        },
+    )
+
+    with OAuthDeviceClient(
+        GITHUB_CLIENT_ID,
+        GITHUB_DEVICE_CODE_URL,
+        GITHUB_ACCESS_TOKEN_URL,
+    ) as client:
+        msg = "Error while fetching access token: Access was denied (access_denied)"
+        with pytest.raises(Exception, match=re.escape(msg)):
+            client.authenticate("read:org")
+
+
+@responses.activate(assert_all_requests_are_fired=True)
+def test_can_add_packit_location(tmp_path):
+    responses.get(
+        "https://example.com/packit/api/outpack/metadata/list",
+        json={"status": "success", "data": []},
+        match=[matchers.header_matcher({"Authorization": "Bearer mytoken"})],
+    )
+
+    root = create_temporary_root(tmp_path)
+    outpack_location_add(
+        "upstream",
+        "packit",
+        {"url": "https://example.com", "token": "mytoken"},
+        root,
+    )
+    outpack_location_pull_metadata("upstream", root=root)

--- a/tests/outpack/test_location_ssh.py
+++ b/tests/outpack/test_location_ssh.py
@@ -127,7 +127,7 @@ def test_can_read_config(tmp_path):
         assert not location.config.core.require_complete_tree
 
 
-def test_can_list_files(tmp_path):
+def test_can_list_packets(tmp_path):
     root = create_temporary_root(tmp_path)
     ids = [create_random_packet(tmp_path) for _ in range(3)]
     packets = root.index.location(LOCATION_LOCAL)

--- a/tests/outpack/test_util.py
+++ b/tests/outpack/test_util.py
@@ -19,7 +19,6 @@ from pyorderly.outpack.util import (
     partition,
     pl,
     read_string,
-    removeprefix,
     time_to_num,
 )
 
@@ -234,8 +233,3 @@ def test_as_posix_path():
         "here/aaa": "there/bbb",
         "foo/bar": "baz/qux",
     }
-
-
-def test_removeprefix():
-    assert removeprefix("foobar", "foo") == "bar"
-    assert removeprefix("foobar", "xxx") == "foobar"


### PR DESCRIPTION
This adds two new location types, "http" and "packit", used to interact with outpack_server and Packit, respectively. The behaviour is based upon the R orderly2 implementation.

Authentication to Packit can be done by providing a Packit JWT, a GitHub PAT or interactively using an OAuth device flow against GitHub. For now, tokens obtained through interactive login are only cached in memory. I need to think about where and how tokens may be saved on disk.

There is no pushing support yet.