### PR TITLE
Modernize type annotations.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,7 +79,7 @@ generate-docs = [
 ]
 
 [[tool.hatch.envs.all.matrix]]
-python = ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
+python = ["3.9", "3.10", "3.11", "3.12", "3.13"]
 
 [tool.hatch.envs.lint]
 extra-dependencies = [
@@ -104,12 +104,10 @@ all = [
 ]
 
 [tool.black]
-target-version = ["py37"]
 line-length = 80
 skip-string-normalization = true
 
 [tool.ruff]
-target-version = "py37"
 line-length = 120
 
 [tool.ruff.lint]
@@ -163,9 +161,6 @@ unfixable = [
   # Don't touch unused imports
   "F401",
 ]
-
-[tool.ruff.lint.isort]
-known-first-party = ["outpack"]
 
 [tool.ruff.lint.flake8-tidy-imports]
 ban-relative-imports = "all"

--- a/src/pyorderly/core.py
+++ b/src/pyorderly/core.py
@@ -3,7 +3,7 @@ import shutil
 from dataclasses import dataclass
 from pathlib import Path
 from types import SimpleNamespace
-from typing import Dict, List, Union
+from typing import Union
 
 from dataclasses_json import dataclass_json
 
@@ -18,7 +18,7 @@ from pyorderly.outpack.util import pl
 @dataclass
 class Artefact:
     name: str
-    files: List[str]
+    files: list[str]
 
 
 @dataclass_json()
@@ -26,7 +26,7 @@ class Artefact:
 class Description:
     display: str
     long: str
-    custom: Dict[str, Union[str, int, bool]]
+    custom: dict[str, Union[str, int, bool]]
 
     @staticmethod
     def empty():
@@ -112,8 +112,8 @@ def resource(files):
 
 
 def shared_resource(
-    files: Union[str, List[str], Dict[str, str]]
-) -> Dict[str, str]:
+    files: Union[str, list[str], dict[str, str]]
+) -> dict[str, str]:
     """Copy shared resources into a packet directory.
 
     You can use this to share common resources (data or code) between multiple
@@ -151,8 +151,8 @@ def shared_resource(
 
 
 def _copy_shared_resources(
-    root: Path, packet: Path, files: Dict[str, str]
-) -> Dict[str, str]:
+    root: Path, packet: Path, files: dict[str, str]
+) -> dict[str, str]:
     shared_path = root / "shared"
     if not shared_path.exists():
         msg = "The shared resources directory 'shared' does not exist at orderly's root"

--- a/src/pyorderly/outpack/config.py
+++ b/src/pyorderly/outpack/config.py
@@ -1,6 +1,6 @@
 import os.path
 from dataclasses import dataclass, field
-from typing import Dict, Optional
+from typing import Optional
 
 from dataclasses_json import config, dataclass_json
 
@@ -80,7 +80,7 @@ class Location:
 class Config:
     schema_version: str
     core: ConfigCore
-    location: Dict[str, Location] = field(
+    location: dict[str, Location] = field(
         metadata=config(
             encoder=_encode_location_dict, decoder=_decode_location_dict
         )

--- a/src/pyorderly/outpack/copy_files.py
+++ b/src/pyorderly/outpack/copy_files.py
@@ -1,6 +1,5 @@
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Dict
 
 from pyorderly.outpack.location_pull import (
     location_build_pull_plan,
@@ -15,12 +14,12 @@ from pyorderly.outpack.search_options import SearchOptions
 class Plan:
     id: str
     name: str
-    files: Dict[str, PacketFile]
+    files: dict[str, PacketFile]
 
 
 def copy_files(
     id: str,
-    files: Dict[str, str],
+    files: dict[str, str],
     dest: Path,
     options: SearchOptions,
     root: OutpackRoot,
@@ -43,7 +42,7 @@ def copy_files(
 
 def copy_files_from_remote(
     id: str,
-    files: Dict[str, PacketFile],
+    files: dict[str, PacketFile],
     dest: Path,
     options: SearchOptions,
     root: OutpackRoot,

--- a/src/pyorderly/outpack/index.py
+++ b/src/pyorderly/outpack/index.py
@@ -1,6 +1,5 @@
 import pathlib
 from dataclasses import dataclass
-from typing import Dict, List
 
 from pyorderly.outpack.metadata import (
     MetadataCore,
@@ -12,9 +11,9 @@ from pyorderly.outpack.metadata import (
 
 @dataclass
 class IndexData:
-    metadata: Dict[str, MetadataCore]
-    location: Dict[str, Dict[str, PacketLocation]]
-    unpacked: List[str]
+    metadata: dict[str, MetadataCore]
+    location: dict[str, dict[str, PacketLocation]]
+    unpacked: list[str]
 
     @staticmethod
     def new():
@@ -34,7 +33,7 @@ class Index:
         self.data = _index_update(self._path, self.data)
         return self
 
-    def all_metadata(self) -> Dict[str, MetadataCore]:
+    def all_metadata(self) -> dict[str, MetadataCore]:
         return self.refresh().data.metadata
 
     def metadata(self, id) -> MetadataCore:
@@ -42,16 +41,16 @@ class Index:
             return self.data.metadata[id]
         return self.refresh().data.metadata[id]
 
-    def all_locations(self) -> Dict[str, Dict[str, PacketLocation]]:
+    def all_locations(self) -> dict[str, dict[str, PacketLocation]]:
         return self.refresh().data.location
 
-    def location(self, name) -> Dict[str, PacketLocation]:
+    def location(self, name) -> dict[str, PacketLocation]:
         return self.refresh().data.location.get(name, {})
 
-    def packets_in_location(self, name) -> List[str]:
+    def packets_in_location(self, name) -> list[str]:
         return list(self.location(name).keys())
 
-    def unpacked(self) -> List[str]:
+    def unpacked(self) -> list[str]:
         return self.refresh().data.unpacked
 
 
@@ -70,7 +69,7 @@ def _read_metadata(path_root, data):
     return data
 
 
-def _read_locations(path_root, data) -> Dict[str, Dict[str, PacketLocation]]:
+def _read_locations(path_root, data) -> dict[str, dict[str, PacketLocation]]:
     path = path_root / ".outpack" / "location"
     for loc in path.iterdir():
         if loc.name not in data:

--- a/src/pyorderly/outpack/location_driver.py
+++ b/src/pyorderly/outpack/location_driver.py
@@ -1,6 +1,6 @@
+import builtins
 from abc import abstractmethod
 from contextlib import AbstractContextManager
-from typing import Dict, List
 
 from pyorderly.outpack.metadata import MetadataCore, PacketFile, PacketLocation
 
@@ -14,10 +14,10 @@ class LocationDriver(AbstractContextManager):
     """
 
     @abstractmethod
-    def list(self) -> Dict[str, PacketLocation]: ...
+    def list(self) -> dict[str, PacketLocation]: ...
 
     @abstractmethod
-    def metadata(self, packet_ids: List[str]) -> Dict[str, str]: ...
+    def metadata(self, packet_ids: builtins.list[str]) -> dict[str, str]: ...
 
     @abstractmethod
     def fetch_file(

--- a/src/pyorderly/outpack/location_http.py
+++ b/src/pyorderly/outpack/location_http.py
@@ -1,5 +1,5 @@
+import builtins
 import shutil
-from typing import Dict, List
 from urllib.parse import urljoin
 
 import requests
@@ -58,7 +58,7 @@ class OutpackLocationHTTP(LocationDriver):
         self._client.__exit__(*args)
 
     @override
-    def list(self) -> Dict[str, PacketLocation]:
+    def list(self) -> dict[str, PacketLocation]:
         response = self._client.get("metadata/list").json()
         data = response["data"]
         return {
@@ -66,7 +66,7 @@ class OutpackLocationHTTP(LocationDriver):
         }
 
     @override
-    def metadata(self, ids: List[str]) -> Dict[str, str]:
+    def metadata(self, ids: builtins.list[str]) -> dict[str, str]:
         result = {}
         for i in ids:
             result[i] = self._client.get(f"metadata/{i}/text").text

--- a/src/pyorderly/outpack/location_packit.py
+++ b/src/pyorderly/outpack/location_packit.py
@@ -2,7 +2,7 @@ import functools
 import re
 import time
 from dataclasses import dataclass
-from typing import Dict, Optional, Union
+from typing import Optional, Union
 from urllib.parse import urljoin
 
 import requests
@@ -165,7 +165,7 @@ class OAuthDeviceClient:
 # - It should check for expiry of tokens and/or check for authentication errors
 #   and purge offending tokens from it.
 @functools.cache
-def packit_authorisation(url: str, token: Optional[str]) -> Dict[str, str]:
+def packit_authorisation(url: str, token: Optional[str]) -> dict[str, str]:
     # If a non-Github token is provided, we assume it is a native Packit token
     # and use that directly.
     if token is not None and not re.match("^gh._", token):

--- a/src/pyorderly/outpack/location_path.py
+++ b/src/pyorderly/outpack/location_path.py
@@ -1,6 +1,6 @@
+import builtins
 import os
 import shutil
-from typing import Dict, List
 
 from typing_extensions import override
 
@@ -24,11 +24,11 @@ class OutpackLocationPath(LocationDriver):
         pass
 
     @override
-    def list(self) -> Dict[str, PacketLocation]:
+    def list(self) -> dict[str, PacketLocation]:
         return self.__root.index.location(LOCATION_LOCAL)
 
     @override
-    def metadata(self, packet_ids: List[str]) -> Dict[str, str]:
+    def metadata(self, packet_ids: builtins.list[str]) -> dict[str, str]:
         all_ids = self.__root.index.location(LOCATION_LOCAL).keys()
         missing_ids = set(packet_ids).difference(all_ids)
         if missing_ids:

--- a/src/pyorderly/outpack/location_pull.py
+++ b/src/pyorderly/outpack/location_pull.py
@@ -1,9 +1,10 @@
 import itertools
 import os
 import time
+from collections.abc import Generator
 from contextlib import contextmanager
 from dataclasses import dataclass
-from typing import Dict, Generator, List, Optional, Set, Union
+from typing import Optional, Union
 
 import humanize
 
@@ -91,8 +92,8 @@ def _get_remove_location_hint(location_name):
 
 def _validate_hashes(
     location_name: str,
-    location_packets: List[PacketLocation],
-    known_packets: Dict[str, PacketLocation],
+    location_packets: list[PacketLocation],
+    known_packets: dict[str, PacketLocation],
 ):
     mismatched_hashes = set()
     for packet in location_packets:
@@ -117,7 +118,7 @@ def _validate_hashes(
 
 
 def _mark_all_known(
-    root: OutpackRoot, location_name: str, packets: List[PacketLocation]
+    root: OutpackRoot, location_name: str, packets: list[PacketLocation]
 ):
     known_already = root.index.packets_in_location(root)
     for packet in packets:
@@ -132,7 +133,7 @@ def _mark_all_known(
 
 
 def outpack_location_pull_packet(
-    ids: Union[str, List[str]],
+    ids: Union[str, list[str]],
     *,
     options: Optional[SearchOptions] = None,
     recursive: Optional[bool] = None,
@@ -223,7 +224,7 @@ non-recursive pull, as this might leave an incomplete tree"""
 # after we hash them the first time).
 @contextmanager
 def location_pull_files(
-    files: List[PacketFileWithLocation], root: OutpackRoot
+    files: list[PacketFileWithLocation], root: OutpackRoot
 ) -> Generator[FileStore, None, None]:
     store = root.files
     cleanup_store = False
@@ -283,7 +284,7 @@ def location_pull_files(
 
 
 def _location_pull_hash_store(
-    files: List[PacketFileWithLocation],
+    files: list[PacketFileWithLocation],
     location_name: str,
     driver: LocationDriver,
     store: FileStore,
@@ -315,7 +316,7 @@ def _pull_missing_metadata(
     driver: LocationDriver,
     root: OutpackRoot,
     location_name: str,
-    packets: List[PacketLocation],
+    packets: list[PacketLocation],
 ):
     known_here = root.index.all_metadata()
 
@@ -337,24 +338,24 @@ class PullPlanInfo:
 
 @dataclass
 class LocationPullPlan:
-    packets: Dict[str, PacketLocation]
-    files: List[PacketFileWithLocation]
+    packets: dict[str, PacketLocation]
+    files: list[PacketFileWithLocation]
     info: PullPlanInfo
 
 
 @dataclass
 class PullPlanPackets:
-    requested: List[str]
-    full: List[str]
-    skip: Set[str]
-    fetch: Set[str]
+    requested: list[str]
+    full: list[str]
+    skip: set[str]
+    fetch: set[str]
 
 
 def location_build_pull_plan(
-    packet_ids: List[str],
-    locations: Optional[List[str]],
+    packet_ids: list[str],
+    locations: Optional[list[str]],
     *,
-    files: Optional[Dict[str, List[str]]] = None,
+    files: Optional[dict[str, list[str]]] = None,
     recursive: bool,
     root: OutpackRoot,
 ) -> LocationPullPlan:
@@ -405,7 +406,7 @@ def location_build_pull_plan(
 
 
 def _location_build_pull_plan_packets(
-    packet_ids: List[str], root: OutpackRoot, *, recursive: Optional[bool]
+    packet_ids: list[str], root: OutpackRoot, *, recursive: Optional[bool]
 ) -> PullPlanPackets:
     requested = packet_ids
     index = root.index
@@ -423,8 +424,8 @@ def _location_build_pull_plan_packets(
 
 
 def _find_all_dependencies(
-    packet_ids: List[str], metadata: Dict[str, MetadataCore]
-) -> List[str]:
+    packet_ids: list[str], metadata: dict[str, MetadataCore]
+) -> list[str]:
     ret = set(packet_ids)
     packets = set(packet_ids)
     while packets:
@@ -445,8 +446,8 @@ def _find_all_dependencies(
 
 
 def _location_build_pull_plan_location(
-    packets: PullPlanPackets, locations: Optional[List[str]], root: OutpackRoot
-) -> List[str]:
+    packets: PullPlanPackets, locations: Optional[list[str]], root: OutpackRoot
+) -> list[str]:
     location_names = location_resolve_valid(
         locations,
         root,
@@ -488,11 +489,11 @@ def _location_build_pull_plan_location(
 
 
 def _location_build_pull_plan_files(
-    packet_ids: Set[str],
-    locations: List[str],
-    files: Dict[str, List[str]],
+    packet_ids: set[str],
+    locations: list[str],
+    files: dict[str, list[str]],
     root: OutpackRoot,
-) -> List[PacketFileWithLocation]:
+) -> list[PacketFileWithLocation]:
     metadata = root.index.all_metadata()
 
     # Find first location within the set which contains each packet
@@ -518,8 +519,8 @@ def _location_build_pull_plan_files(
 
 
 def _location_build_packet_locations(
-    packets: Set[str], locations: List[str], root: OutpackRoot
-) -> Dict[str, PacketLocation]:
+    packets: set[str], locations: list[str], root: OutpackRoot
+) -> dict[str, PacketLocation]:
     packets_fetch = {}
     for location in locations:
         packets_from_location = root.index.location(location)

--- a/src/pyorderly/outpack/location_ssh.py
+++ b/src/pyorderly/outpack/location_ssh.py
@@ -1,8 +1,8 @@
 import base64
+import builtins
 import errno
 from contextlib import ExitStack
 from pathlib import PurePosixPath
-from typing import Dict, List
 from urllib.parse import urlsplit
 
 import paramiko
@@ -104,7 +104,7 @@ class OutpackLocationSSH(LocationDriver):
         return self._stack.__exit__(*args)
 
     @override
-    def list(self) -> Dict[str, PacketLocation]:
+    def list(self) -> dict[str, PacketLocation]:
         path = self._root / ".outpack" / "location" / LOCATION_LOCAL
         result = {}
         for packet in self._sftp.listdir(str(path)):
@@ -113,7 +113,7 @@ class OutpackLocationSSH(LocationDriver):
         return result
 
     @override
-    def metadata(self, ids: List[str]) -> Dict[str, str]:
+    def metadata(self, ids: builtins.list[str]) -> dict[str, str]:
         path = self._root / ".outpack" / "metadata"
         result = {}
 

--- a/src/pyorderly/outpack/metadata.py
+++ b/src/pyorderly/outpack/metadata.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Dict, List, Optional, Union
+from typing import Optional, Union
 
 from dataclasses_json import DataClassJsonMixin
 
@@ -44,14 +44,14 @@ class PacketDependsPath(DataClassJsonMixin):
 class PacketDepends(DataClassJsonMixin):
     packet: str
     query: str
-    files: List[PacketDependsPath]
+    files: list[PacketDependsPath]
 
     @staticmethod
     def files_from_dict(files):
         return [{"here": h, "there": t} for h, t, in files.items()]
 
 
-Parameters = Dict[str, Union[bool, int, float, str]]
+Parameters = dict[str, Union[bool, int, float, str]]
 
 
 @dataclass
@@ -60,9 +60,9 @@ class MetadataCore(DataClassJsonMixin):
     id: str
     name: str
     parameters: Parameters
-    time: Dict[str, float]
-    files: List[PacketFile]
-    depends: List[PacketDepends]
+    time: dict[str, float]
+    files: list[PacketFile]
+    depends: list[PacketDepends]
     git: Optional[GitInfo]
     custom: Optional[dict]
 

--- a/src/pyorderly/outpack/search.py
+++ b/src/pyorderly/outpack/search.py
@@ -1,7 +1,7 @@
 import os
 from dataclasses import dataclass
 from itertools import chain
-from typing import Any, Dict, Optional, Set, Union
+from typing import Any, Optional, Union
 
 import outpack_query_parser as parser
 
@@ -56,7 +56,7 @@ class QueryEnv:
 
 class QueryIndex:
     root: OutpackRoot
-    index: Dict[str, MetadataCore]
+    index: dict[str, MetadataCore]
     options: SearchOptions
 
     def __init__(self, root, options):
@@ -98,7 +98,7 @@ def search(
     root: Union[OutpackRoot, str, os.PathLike],
     options: Optional[SearchOptions] = None,
     this: Optional[Parameters] = None,
-) -> Set[str]:
+) -> set[str]:
     """
     Search an outpack repository for all packets that match the given query.
 
@@ -179,7 +179,7 @@ def eval_test_value(
         raise NotImplementedError(msg)
 
 
-def eval_latest(node: parser.Latest, env: QueryEnv) -> Set[str]:
+def eval_latest(node: parser.Latest, env: QueryEnv) -> set[str]:
     if node.inner:
         candidates = eval_query(node.inner, env)
     else:
@@ -191,7 +191,7 @@ def eval_latest(node: parser.Latest, env: QueryEnv) -> Set[str]:
         return set()
 
 
-def eval_single(node: parser.Single, env: QueryEnv) -> Set[str]:
+def eval_single(node: parser.Single, env: QueryEnv) -> set[str]:
     candidates = eval_query(node.inner, env)
     if len(candidates) != 1:
         msg = f"Query found {len(candidates)} packets, but expected exactly one"
@@ -231,7 +231,7 @@ def eval_test_one(
         raise NotImplementedError(msg)
 
 
-def eval_test(node: parser.Test, env: QueryEnv) -> Set[str]:
+def eval_test(node: parser.Test, env: QueryEnv) -> set[str]:
     return {
         packet_id
         for (packet_id, metadata) in env.index.index.items()
@@ -239,7 +239,7 @@ def eval_test(node: parser.Test, env: QueryEnv) -> Set[str]:
     }
 
 
-def eval_boolean(node: parser.BooleanExpr, env: QueryEnv) -> Set[str]:
+def eval_boolean(node: parser.BooleanExpr, env: QueryEnv) -> set[str]:
     lhs = eval_query(node.lhs, env)
     rhs = eval_query(node.rhs, env)
 
@@ -252,12 +252,12 @@ def eval_boolean(node: parser.BooleanExpr, env: QueryEnv) -> Set[str]:
         raise NotImplementedError(msg)
 
 
-def eval_negation(node: parser.Negation, env: QueryEnv) -> Set[str]:
+def eval_negation(node: parser.Negation, env: QueryEnv) -> set[str]:
     complement = eval_query(node.inner, env)
     return set(env.index.index.keys()).difference(complement)
 
 
-def eval_query(node, env: QueryEnv) -> Set[str]:
+def eval_query(node, env: QueryEnv) -> set[str]:
     if isinstance(node, parser.Latest):
         return eval_latest(node, env)
     elif isinstance(node, parser.Single):

--- a/src/pyorderly/outpack/search_options.py
+++ b/src/pyorderly/outpack/search_options.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from typing import List, Optional
+from typing import Optional
 
 
 @dataclass
@@ -20,7 +20,7 @@ class SearchOptions:
         searching
     """
 
-    location: Optional[List[str]] = None
+    location: Optional[list[str]] = None
     allow_remote: bool = False
     pull_metadata: bool = False
 

--- a/src/pyorderly/outpack/tools.py
+++ b/src/pyorderly/outpack/tools.py
@@ -1,5 +1,4 @@
 from dataclasses import dataclass
-from typing import List
 
 import pygit2
 from dataclasses_json import dataclass_json
@@ -10,7 +9,7 @@ from dataclasses_json import dataclass_json
 class GitInfo:
     sha: str
     branch: str
-    url: List[str]
+    url: list[str]
 
 
 def git_info(path):

--- a/src/pyorderly/outpack/util.py
+++ b/src/pyorderly/outpack/util.py
@@ -5,7 +5,7 @@ import time
 from contextlib import contextmanager
 from itertools import filterfalse, tee
 from pathlib import Path, PurePath
-from typing import Dict, List, Optional, Union, overload
+from typing import Optional, Union, overload
 
 
 def find_file_descend(filename, path):
@@ -114,7 +114,7 @@ def match_value(arg, choices, name):
         raise Exception(msg)
 
 
-def relative_path_array(files: Union[str, List[str]], name: str) -> List[str]:
+def relative_path_array(files: Union[str, list[str]], name: str) -> list[str]:
     if not isinstance(files, list):
         files = [files]
 
@@ -125,8 +125,8 @@ def relative_path_array(files: Union[str, List[str]], name: str) -> List[str]:
 
 
 def relative_path_mapping(
-    files: Union[str, List[str], Dict[str, str]], name: str
-) -> Dict[str, str]:
+    files: Union[str, list[str], dict[str, str]], name: str
+) -> dict[str, str]:
     if isinstance(files, str):
         files = {files: files}
     elif isinstance(files, list):
@@ -197,11 +197,11 @@ def as_posix_path(paths: str) -> str: ...
 
 
 @overload
-def as_posix_path(paths: List[str]) -> List[str]: ...
+def as_posix_path(paths: list[str]) -> list[str]: ...
 
 
 @overload
-def as_posix_path(paths: Dict[str, str]) -> Dict[str, str]: ...
+def as_posix_path(paths: dict[str, str]) -> dict[str, str]: ...
 
 
 def as_posix_path(paths):

--- a/src/pyorderly/run.py
+++ b/src/pyorderly/run.py
@@ -1,7 +1,6 @@
 import runpy
 import shutil
 from pathlib import Path
-from typing import Tuple
 
 from pyorderly.core import Description
 from pyorderly.current import ActiveOrderlyContext, OrderlyCustomMetadata
@@ -106,7 +105,7 @@ def _run_report_script(
     return orderly
 
 
-def _validate_src_directory(name, root) -> Tuple[Path, str]:
+def _validate_src_directory(name, root) -> tuple[Path, str]:
     path = root.path / "src" / name
     entrypoint = f"{name}.py"
 

--- a/tests/helpers/__init__.py
+++ b/tests/helpers/__init__.py
@@ -6,7 +6,7 @@ import textwrap
 from contextlib import contextmanager
 from pathlib import Path
 from tempfile import TemporaryDirectory
-from typing import List, Optional
+from typing import Optional
 
 import pytest
 
@@ -121,7 +121,7 @@ def copy_shared_resources(names, root):
             shutil.copyfile(src, dst)
 
 
-def create_metadata_depends(id: str, depends: Optional[List[str]] = None):
+def create_metadata_depends(id: str, depends: Optional[list[str]] = None):
     if depends is None:
         depends = []
     dependencies = [

--- a/tests/helpers/ssh_server.py
+++ b/tests/helpers/ssh_server.py
@@ -5,7 +5,7 @@ import sys
 import threading
 from contextlib import AbstractContextManager, ExitStack
 from pathlib import Path
-from typing import List, Optional
+from typing import Optional
 
 import paramiko
 
@@ -26,7 +26,7 @@ class SSHServer(AbstractContextManager):
     port: int
     host_key: paramiko.PKey
 
-    def __init__(self, root, allowed_users: Optional[List[str]] = None):
+    def __init__(self, root, allowed_users: Optional[list[str]] = None):
         self.root = root
         self.allowed_users = allowed_users
         self.host_key = paramiko.RSAKey.generate(bits=1024)

--- a/tests/outpack/test_location_http.py
+++ b/tests/outpack/test_location_http.py
@@ -1,5 +1,3 @@
-from typing import Dict
-
 import pytest
 import requests
 import responses
@@ -37,7 +35,7 @@ def test_can_list_packets(tmp_path):
     ids = [create_random_packet(tmp_path) for _ in range(3)]
     packets = root.index.location(LOCATION_LOCAL)
 
-    def filter_out_time(data: Dict[str, PacketLocation]) -> Dict[str, dict]:
+    def filter_out_time(data: dict[str, PacketLocation]) -> dict[str, dict]:
         # outpack_server doesn't roundtrip the floating-point time field very
         # well, which leads to flaky tests.
         return {


### PR DESCRIPTION
With Python 3.8 having reached end-of-life, we can move on from using the type definitions from `typing` and instead use the built-in types as annotations, following PEP585.

The only manual change comes from updating the target version in pyproject. More acurately, the ruff/black target version was removed, making it so that the `requires-python` line gets used instead (currently set to 3.9). Everything else was done automatically by running ruff.