### PR TITLE
Fix various build issues

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -2,11 +2,8 @@ name: Docs
 
 on:
   push:
-    branches:
-      - main
+    branches: [ main ]
   pull_request:
-    branches:
-      - main
 
 jobs:
   run:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ jobs:
         run: |
           python -m build
       - name: Upload artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           if-no-files-found: error
           name: python-artifacts
@@ -45,7 +45,7 @@ jobs:
       id-token: write
     steps:
     - name: Download the artifacts
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: python-artifacts
         path: dist/

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,6 @@ on:
     branches: [ main ]
     tags: [ v* ]
   pull_request:
-    branches: [ main ]
 
 name: Publish package
 jobs:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,12 +1,9 @@
 name: Test
 
 on:
-  pull_request:
-    branches:
-      - main
   push:
-    branches:
-      - main
+    branches: [ main ]
+  pull_request:
 
 jobs:
   run:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -47,7 +47,6 @@ jobs:
         with:
           crate: outpack
           git: https://github.com/mrc-ide/outpack_server
-          features: git2/vendored-libgit2
 
       - name: Test
         run: |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -177,6 +177,11 @@ source_pkgs = ["pyorderly", "tests"]
 branch = true
 parallel = true
 
+# Reports run using subprocesses. We need this in order to gather coverage in
+# the child processes.
+# https://pytest-cov.readthedocs.io/en/latest/subprocess-support.html
+patch = ["subprocess"]
+
 # The wildcards are needed in order for the omit path to work correctly even
 # when spawning subprocess in different directories.
 omit = [

--- a/src/pyorderly/core.py
+++ b/src/pyorderly/core.py
@@ -112,7 +112,7 @@ def resource(files):
 
 
 def shared_resource(
-    files: Union[str, list[str], dict[str, str]]
+    files: Union[str, list[str], dict[str, str]],
 ) -> dict[str, str]:
     """Copy shared resources into a packet directory.
 

--- a/src/pyorderly/outpack/config.py
+++ b/src/pyorderly/outpack/config.py
@@ -51,12 +51,12 @@ class ConfigCore:
 class Location:
     name: str
     type: str
-    args: Optional[dict] = None
+    args: dict
 
     def __init__(self, name, type, args=None):
         self.name = name
         self.type = type
-        self.args = args
+        self.args = args if args is not None else {}
 
         match_value(self.type, LOCATION_TYPES, "type")
         required = set()
@@ -67,7 +67,7 @@ class Location:
         elif type == "custom":
             required = {"driver"}
 
-        present = set() if self.args is None else set(self.args.keys())
+        present = self.args.keys()
         missing = required - present
         if missing:
             missing_text = "', '".join(missing)

--- a/src/pyorderly/outpack/util.py
+++ b/src/pyorderly/outpack/util.py
@@ -66,7 +66,8 @@ def assert_file_exists(path, *, workdir=None, name="File"):
             missing = [str(p) for p in path if not os.path.exists(p)]
         else:
             missing = [] if os.path.exists(path) else [path]
-    if len(missing):
+
+    if missing:
         missing_str = ", ".join(missing)
         msg = f"{name} does not exist: {missing_str}"
         raise Exception(msg)

--- a/tests/helpers/ssh_server.py
+++ b/tests/helpers/ssh_server.py
@@ -81,7 +81,7 @@ class SSHServer(AbstractContextManager):
 
     def _server_loop(self, sock: socket.socket):
         while True:
-            client, addr = sock.accept()
+            client, _addr = sock.accept()
             if self.shutdown.is_set():
                 return
 

--- a/tests/orderly/test_run.py
+++ b/tests/orderly/test_run.py
@@ -74,20 +74,20 @@ def test_validate_report_src_directory(tmp_path):
     path_src.mkdir()
 
     x = path_src / "x"
-    with pytest.raises(Exception, match="The path '.+/x' does not exist"):
+    with pytest.raises(Exception, match=r"The path '.+/x' does not exist"):
         _validate_src_directory("x", root)
 
     x.mkdir()
     with pytest.raises(
         Exception,
-        match="The path '.+/x' exists but does not contain 'x.py'",
+        match=r"The path '.+/x' exists but does not contain 'x\.py'",
     ):
         _validate_src_directory("x", root)
 
     y = path_src / "y"
     y.touch()
     with pytest.raises(
-        Exception, match="The path '.+/y' exists but is not a directory"
+        Exception, match=r"The path '.+/y' exists but is not a directory"
     ):
         _validate_src_directory("y", root)
 
@@ -186,7 +186,7 @@ with open("report.py", "w") as f:
 """
 
     with pytest.raises(
-        Exception, match="File was changed after being added: report.py"
+        Exception, match="File was changed after being added: report\\.py"
     ):
         helpers.run_snippet("report", code, root)
 
@@ -203,7 +203,7 @@ with open("data.txt", "w") as f:
     helpers.write_file(tmp_path / "src" / "report" / "data.txt", "old data")
 
     with pytest.raises(
-        Exception, match="File was changed after being added: data.txt"
+        Exception, match="File was changed after being added: data\\.txt"
     ):
         helpers.run_snippet("report", code, root)
 
@@ -409,13 +409,13 @@ def test_can_validate_parameters():
     assert _validate_parameters(None, {"a": 1}) == {"a": 1}
     with pytest.raises(Exception, match="Parameters given, but none declared"):
         _validate_parameters({"a": 1}, {})
-    with pytest.raises(Exception, match="Missing parameters: a"):
+    with pytest.raises(Exception, match=r"Missing parameters: a"):
         _validate_parameters({}, {"a": None})
-    with pytest.raises(Exception, match="Missing parameters: ., .$"):
+    with pytest.raises(Exception, match=r"Missing parameters: ., .$"):
         _validate_parameters({}, {"a": None, "b": None})
-    with pytest.raises(Exception, match="Missing parameters: b$"):
+    with pytest.raises(Exception, match=r"Missing parameters: b$"):
         _validate_parameters({}, {"a": 1, "b": None})
-    with pytest.raises(Exception, match="Unknown parameters: b$"):
+    with pytest.raises(Exception, match=r"Unknown parameters: b$"):
         _validate_parameters({"b": 1}, {"a": 1})
     err = "Expected parameter a to be a simple value"
     with pytest.raises(Exception, match=err):
@@ -446,7 +446,7 @@ def test_pycache_is_not_copied_from_source(tmp_path):
 import glob
 return glob.glob("**/*", recursive=True)
 """
-    id, files = helpers.run_snippet("report", code, root)
+    _id, files = helpers.run_snippet("report", code, root)
 
     assert set(files) == {
         "report.py",

--- a/tests/orderly/test_run_metadata.py
+++ b/tests/orderly/test_run_metadata.py
@@ -68,8 +68,6 @@ def test_shared_resource_can_copy_single_name(tmp_path):
 
 
 def test_shared_resource_can_copy_multiple_names(tmp_path):
-    from os.path import join
-
     root = helpers.create_temporary_root(tmp_path)
     helpers.copy_shared_resources(["numbers.txt", "data"], root)
 
@@ -83,8 +81,12 @@ def test_shared_resource_can_copy_multiple_names(tmp_path):
     assert (src / "data" / "numbers.txt").exists()
     assert res == {
         "numbers.txt": "numbers.txt",
-        join("data", "numbers.txt"): join("data", "numbers.txt"),
-        join("data", "weights.txt"): join("data", "weights.txt"),
+        os.path.join("data", "numbers.txt"): os.path.join(
+            "data", "numbers.txt"
+        ),
+        os.path.join("data", "weights.txt"): os.path.join(
+            "data", "weights.txt"
+        ),
     }
 
 
@@ -244,11 +246,11 @@ def test_can_use_parameters_without_packet(tmp_path):
         assert p == pyorderly.Parameters(x=1, y="foo")
 
         with pytest.raises(
-            Exception, match="No value was specified for parameter x."
+            Exception, match="No value was specified for parameter x\\."
         ):
             pyorderly.parameters(x=None, y="foo")
 
         with pytest.raises(
-            Exception, match="No value was specified for parameters x, y."
+            Exception, match="No value was specified for parameters x, y\\."
         ):
             pyorderly.parameters(x=None, y=None)

--- a/tests/outpack/test_init.py
+++ b/tests/outpack/test_init.py
@@ -21,7 +21,7 @@ def test_fail_to_create_with_error_if_path_exists(tmp_path):
     root = tmp_path / "root"
     root.touch()
     with pytest.raises(
-        Exception, match="Path '.+' already exists but is not a directory"
+        Exception, match=r"Path '.+' already exists but is not a directory"
     ):
         outpack_init(root)
 

--- a/tests/outpack/test_metadata.py
+++ b/tests/outpack/test_metadata.py
@@ -86,5 +86,5 @@ def test_can_get_file_hash_from_metadata():
 
 def test_can_error_if_file_not_found_in_metadata():
     d = read_metadata_core("example/.outpack/metadata/20230807-152344-ee606dce")
-    with pytest.raises(Exception, match="Packet .+ does not contain file 'f'"):
+    with pytest.raises(Exception, match=r"Packet .+ does not contain file 'f'"):
         d.file_hash("f")

--- a/tests/outpack/test_packet.py
+++ b/tests/outpack/test_packet.py
@@ -60,7 +60,7 @@ def test_cant_end_packet_twice(tmp_path):
 
     p = Packet(root, src, "data")
     p.end()
-    with pytest.raises(Exception, match="Packet '.+' already ended"):
+    with pytest.raises(Exception, match=r"Packet '.+' already ended"):
         p.end()
 
 
@@ -154,7 +154,7 @@ def test_can_detect_changes_to_immutable_files(tmp_path):
 
     with pytest.raises(
         Exception,
-        match="File was changed after being added: data.csv",
+        match="File was changed after being added: data\\.csv",
     ):
         with create_packet(root, "data") as p:
             p.path.joinpath("data.csv").write_text("a,b\n1,2\n3,4\n")
@@ -188,7 +188,7 @@ def test_can_detect_modification_of_immutable_file(tmp_path):
     p1.mark_file_immutable("data.csv")
     with open(src / "data.csv", "w") as f:
         f.write("a,b\n1,2\n3,4\n5,6\n")
-    with pytest.raises(Exception, match="Hash of '.+' does not match"):
+    with pytest.raises(Exception, match=r"Hash of '.+' does not match"):
         p1.mark_file_immutable("data.csv")
     p = Packet(root, src, "data")
     with open(src / "data.csv", "w") as f:
@@ -212,7 +212,7 @@ def test_can_detect_modification_of_immutable_file_if_readded(tmp_path):
     p.mark_file_immutable("data.csv")
     with open(src / "data.csv", "a") as f:
         f.write("5,6\n")
-    with pytest.raises(Exception, match="Hash of .+ does not match"):
+    with pytest.raises(Exception, match=r"Hash of .+ does not match"):
         p.mark_file_immutable("data.csv")
 
 

--- a/tests/outpack/test_sandbox.py
+++ b/tests/outpack/test_sandbox.py
@@ -76,7 +76,7 @@ def test_sandbox_can_run_in_different_directory(tmp_path):
 
 
 def sandbox_can_import_local_modules():
-    import my_unique_module_name  # noqa: PLC0415, type: ignore
+    import my_unique_module_name  # type: ignore # noqa: PLC0415
 
     return my_unique_module_name.hello()
 

--- a/tests/outpack/test_sandbox.py
+++ b/tests/outpack/test_sandbox.py
@@ -76,7 +76,7 @@ def test_sandbox_can_run_in_different_directory(tmp_path):
 
 
 def sandbox_can_import_local_modules():
-    import my_unique_module_name  # type: ignore
+    import my_unique_module_name  # noqa: PLC0415, type: ignore
 
     return my_unique_module_name.hello()
 
@@ -93,7 +93,7 @@ def test_sandbox_can_import_local_modules(tmp_path):
 
 
 def sandbox_does_not_share_modules_cache():
-    import my_unique_module_name
+    import my_unique_module_name  # noqa: PLC0415
 
     return my_unique_module_name.MESSAGE
 

--- a/tests/outpack/test_search.py
+++ b/tests/outpack/test_search.py
@@ -108,12 +108,12 @@ def test_search_unique_fails_on_non_single_values(tmp_path):
     id = create_random_packet(root)
 
     with pytest.raises(
-        Exception, match="Query is not guaranteed to return a single packet."
+        Exception, match="Query is not guaranteed to return a single packet\\."
     ):
         search_unique("name == 'data'", root=root)
 
     with pytest.raises(
-        Exception, match="Query is not guaranteed to return a single packet."
+        Exception, match="Query is not guaranteed to return a single packet\\."
     ):
         search_unique(f"id != '{id}'", root=root)
 

--- a/tests/outpack/test_util.py
+++ b/tests/outpack/test_util.py
@@ -217,17 +217,15 @@ def test_openable_temporary_file():
 
 
 def test_as_posix_path():
-    from os.path import join
-
-    input = join("foo", "bar", "baz")
+    input = os.path.join("foo", "bar", "baz")
     assert as_posix_path(input) == "foo/bar/baz"
 
-    input = [join("hello", "world"), join("foo", "bar", "baz")]
+    input = [os.path.join("hello", "world"), os.path.join("foo", "bar", "baz")]
     assert as_posix_path(input) == ["hello/world", "foo/bar/baz"]
 
     input = {
-        join("here", "aaa"): join("there", "bbb"),
-        join("foo", "bar"): join("baz", "qux"),
+        os.path.join("here", "aaa"): os.path.join("there", "bbb"),
+        os.path.join("foo", "bar"): os.path.join("baz", "qux"),
     }
     assert as_posix_path(input) == {
         "here/aaa": "there/bbb",


### PR DESCRIPTION
- Ruff has added a few more lints that we need to account for ([RUF043](https://docs.astral.sh/ruff/rules/pytest-raises-ambiguous-pattern/#pytest-raises-ambiguous-pattern-ruf043), [PLS0415](https://docs.astral.sh/ruff/rules/import-outside-top-level/#import-outside-top-level-plc0415), [RUF059](https://docs.astral.sh/ruff/rules/unused-unpacked-variable/))
- Github has dropped support for upload-artifact v3
- outpack_server has removed its dependency on libgit2, which means we need to remove the feature flag
- outpack_server has become stricter about the type of the `args` field in the config. It must be an object (albeit empty), never null.
- [pytest-cov 7](https://pytest-cov.readthedocs.io/en/latest/subprocess-support.html) has stopped enabling subprocess support by default, so we need to re-enable it explicitly.