### PR TITLE
mrc-6830 update packit api urls

### DIFF
--- a/src/pyorderly/__about__.py
+++ b/src/pyorderly/__about__.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: 2023-present Rich FitzJohn <r.fitzjohn@imperial.ac.uk>
 #
 # SPDX-License-Identifier: MIT
-__version__ = "0.2.0"
+__version__ = "0.2.1"
 __name__ = "pyorderly"

--- a/src/pyorderly/outpack/location_packit.py
+++ b/src/pyorderly/outpack/location_packit.py
@@ -34,8 +34,8 @@ def packit_authorisation(url: str, token: str | None) -> dict[str, str]:
     print(f"Logging in to {url}")
     with OAuthDeviceClient(
         client_id="pyorderly",
-        device_code_url=urljoin(url, "packit/api/deviceAuth"),
-        access_token_url=urljoin(url, "packit/api/deviceAuth/token"),
+        device_code_url=urljoin(url, "api/deviceAuth"),
+        access_token_url=urljoin(url, "api/deviceAuth/token"),
     ) as client:
         token = client.authenticate().access_token
 
@@ -50,6 +50,6 @@ def outpack_location_packit(
         url += "/"
 
     return OutpackLocationHTTP(
-        urljoin(url, "packit/api/outpack/"),
+        urljoin(url, "api/outpack/"),
         lambda: packit_authorisation(url, token),
     )

--- a/tests/outpack/test_location_packit.py
+++ b/tests/outpack/test_location_packit.py
@@ -27,7 +27,7 @@ def clear_authentication_cache():
 @responses.activate(assert_all_requests_are_fired=True)
 def test_can_pass_packit_token():
     responses.get(
-        "https://example.com/packit/api/outpack/metadata/list",
+        "https://example.com/api/outpack/metadata/list",
         json={"status": "success", "data": []},
         match=[matchers.header_matcher({"Authorization": "Bearer mytoken"})],
     )
@@ -38,7 +38,7 @@ def test_can_pass_packit_token():
 
 def register_oauth_responses(token):
     device_code = responses.post(
-        "https://example.com/packit/api/deviceAuth",
+        "https://example.com/api/deviceAuth",
         json={
             "device_code": "xxxxx",
             "user_code": "1234-5678",
@@ -48,7 +48,7 @@ def register_oauth_responses(token):
         },
     )
     access_token = responses.post(
-        "https://example.com/packit/api/deviceAuth/token",
+        "https://example.com/api/deviceAuth/token",
         json={"access_token": token, "token_type": "bearer"},
     )
     return SimpleNamespace(device_code=device_code, access_token=access_token)
@@ -59,7 +59,7 @@ def test_can_perform_interactive_authentication(capsys):
     register_oauth_responses(token="mytoken")
 
     responses.get(
-        "https://example.com/packit/api/outpack/metadata/list",
+        "https://example.com/api/outpack/metadata/list",
         match=[matchers.header_matcher({"Authorization": "Bearer mytoken"})],
         json={"status": "success", "data": []},
     )
@@ -76,7 +76,7 @@ def test_authentication_is_cached():
     mocks = register_oauth_responses("mytoken")
 
     list_response = responses.get(
-        "https://example.com/packit/api/outpack/metadata/list",
+        "https://example.com/api/outpack/metadata/list",
         match=[matchers.header_matcher({"Authorization": "Bearer mytoken"})],
         json={"status": "success", "data": []},
     )
@@ -106,7 +106,7 @@ def test_github_personal_token_is_rejected():
 @responses.activate(assert_all_requests_are_fired=True)
 def test_can_add_packit_location(tmp_path):
     responses.get(
-        "https://example.com/packit/api/outpack/metadata/list",
+        "https://example.com/api/outpack/metadata/list",
         json={"status": "success", "data": []},
         match=[matchers.header_matcher({"Authorization": "Bearer mytoken"})],
     )


### PR DESCRIPTION
The packit api base route is now `/api` not `/packit/api`. This branch updates all urls - this has already been done in R orderly. 